### PR TITLE
ワークフローのpaths-ignoreを整理・統一

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,11 @@ on:
         branches:
             - develop
         paths-ignore:
-            - .vscode/**
-            - .claude/**
-            - .gitignore
-            - README.md
+            - '.vscode/**'
+            - '.claude/**'
+            - '.gitignore'
+            - '**/*.md'
+            - '.github/workflows/!(build).yml'
     workflow_dispatch: # テスト用の手動実行
 
 permissions:
@@ -119,8 +120,8 @@ jobs:
             # ビルド証明の生成
             - name: Attest build provenance
               uses: actions/attest-build-provenance@v1
-              if: github.event_name != 'workflow_dispatch'  # 手動実行時はスキップ
-              continue-on-error: true  # エラーが発生してもワークフローを続行
+              if: github.event_name != 'workflow_dispatch' # 手動実行時はスキップ
+              continue-on-error: true # エラーが発生してもワークフローを続行
               with:
                   subject-name: ${{ matrix.service.image }}
                   subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,16 @@
 name: Deploy to Production
 
 on:
-    # mainブランチへのマージ時
     push:
         branches:
             - main
         paths-ignore:
-            - .vscode/**
-            - .claude/**
-            - .gitignore
-            - README.md
-    # 手動実行
-    workflow_dispatch:
+            - '.vscode/**'
+            - '.claude/**'
+            - '.gitignore'
+            - '**/*.md'
+            - '.github/workflows/!(deploy).yml'
+    workflow_dispatch: # テスト用の手動実行
         inputs:
             tag:
                 description: 'デプロイするイメージタグ (デフォルト: staging)'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,12 +2,14 @@ name: PR checks (develop)
 
 on:
     pull_request:
-        branches: [develop]
+        branches:
+            - develop
         paths-ignore:
             - '.vscode/**'
             - '.claude/**'
             - '.gitignore'
             - '**/*.md'
+            - '.github/workflows/!(pr-checks).yml'
     workflow_dispatch: # テスト用の手動実行
 
 jobs:


### PR DESCRIPTION
- すべてのワークフローでpaths-ignore形式を統一
- マークダウンファイルを`**/*.md`で一括除外
- 各ワークフローで自分以外のワークフローファイルを除外
  - build.yml: `!(build).yml`を除外
  - deploy.yml: `!(deploy).yml`を除外
  - pr-checks.yml: `!(pr-checks).yml`を除外