### PR TITLE
本番環境用docker-compose-prod.ymlを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,4 +202,56 @@ Pull Request 作成時に自動実行：
 ### コンテナイメージのタグ戦略
 
 -   `staging`: develop ブランチの最新ビルド
+-   `release`: 本番環境用の安定版
 -   `sha-<commit>`: 特定コミットのビルド
+
+## 本番環境へのデプロイ
+
+本番環境では`docker-compose-prod.yml`を使用します。このファイルは、GitHub Container Registryにプッシュされたリリースイメージを使用します。
+
+### 初回セットアップ
+
+1. **必要なファイルの準備**
+   ```bash
+   # リポジトリのクローン
+   git clone https://github.com/kagiyama-baking/kawashiro-server.git
+   cd kawashiro-server
+
+   # .envファイルの作成（Immich用の環境変数）
+   cp .env.example .env
+   # 必要に応じて.envファイルを編集
+   ```
+
+2. **イメージの取得と起動**
+   ```bash
+   # 最新のイメージをプル
+   docker compose -f docker-compose-prod.yml pull
+
+   # サービスの起動
+   docker compose -f docker-compose-prod.yml up -d
+   ```
+
+### 運用コマンド
+
+```bash
+# イメージの更新と再起動
+docker compose -f docker-compose-prod.yml pull
+docker compose -f docker-compose-prod.yml up -d --force-recreate
+
+# ログの確認
+docker compose -f docker-compose-prod.yml logs -f
+
+# 特定サービスのログ確認
+docker compose -f docker-compose-prod.yml logs -f reverse-proxy
+
+# サービスの停止
+docker compose -f docker-compose-prod.yml down
+
+# サービスの状態確認
+docker compose -f docker-compose-prod.yml ps
+```
+
+### 本番環境で使用されるイメージ
+
+- `ghcr.io/kagiyama-baking/kawashiro-server/reverse-proxy:release`
+- `ghcr.io/kagiyama-baking/kawashiro-server/test-web:release`

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,0 +1,126 @@
+services:
+    # リバースプロキシサーバー
+    reverse-proxy:
+        image: ghcr.io/kagiyama-baking/kawashiro-server/reverse-proxy:release
+        container_name: reverse-proxy
+        hostname: reverse-proxy
+        ports:
+            - '80:8080'
+            # HTTPS用（必要に応じてコメントアウトを解除）
+            # - "443:443"
+        volumes:
+            # ファイルのマウント
+            - ./reverse_proxy/nginx.conf:/etc/nginx/nginx.conf:ro
+            - ./reverse_proxy/conf.d:/etc/nginx/conf.d:ro
+            - ./reverse_proxy/html:/usr/share/nginx/html:ro
+            # ログの永続化
+            - ./volumes/reverse-proxy/log/nginx:/var/log/nginx
+        restart: unless-stopped
+        depends_on:
+            - test-web
+            - immich
+        networks:
+            - proxy-network
+
+    # テスト用Webサーバー
+    test-web:
+        image: ghcr.io/kagiyama-baking/kawashiro-server/test-web:release
+        container_name: test-web
+        hostname: test-web
+        volumes:
+            # ファイルのマウント
+            - ./test_web/conf.d:/etc/nginx/conf.d:ro
+            - ./test_web/html:/usr/share/nginx/html:ro
+            # ログの永続化
+            - ./volumes/test-web/log/nginx:/var/log/nginx
+        restart: unless-stopped
+        networks:
+            - proxy-network
+
+    # Immich - 写真管理サービス
+    immich:
+        image: ghcr.io/immich-app/immich-server:release
+        container_name: immich
+        hostname: immich
+        environment:
+            # Docker Composeサービス名を使用
+            DB_HOSTNAME: immich-postgres
+            REDIS_HOSTNAME: immich-redis
+        env_file:
+            - .env
+        volumes:
+            # アップロードファイルの永続化
+            - ./volumes/immich/data:/data
+            # ログディレクトリの作成（アプリケーションログ用）
+            - ./volumes/immich/log:/logs
+            # タイムゾーン設定
+            - /etc/localtime:/etc/localtime:ro
+        depends_on:
+            - immich-redis
+            - immich-postgres
+        restart: unless-stopped
+        networks:
+            - proxy-network
+
+    # Immich Machine Learning
+    immich-machine-learning:
+        image: ghcr.io/immich-app/immich-machine-learning:release
+        container_name: immich-ml
+        hostname: immich-ml
+        environment:
+            # Docker Composeサービス名を使用
+            DB_HOSTNAME: immich-postgres
+            REDIS_HOSTNAME: immich-redis
+        env_file:
+            - .env
+        volumes:
+            # モデルキャッシュの永続化
+            - immich-ml-cache:/cache
+        restart: unless-stopped
+        networks:
+            - proxy-network
+
+    # Redis for Immich
+    immich-redis:
+        image: docker.io/valkey/valkey:8-bookworm
+        container_name: immich-redis
+        hostname: immich-redis
+        healthcheck:
+            test: redis-cli ping || exit 1
+        volumes:
+            # Redisデータの永続化
+            - immich-redis-data:/data
+        restart: unless-stopped
+        networks:
+            - proxy-network
+
+    # PostgreSQL for Immich
+    immich-postgres:
+        image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0
+        container_name: immich-postgres
+        hostname: immich-postgres
+        environment:
+            POSTGRES_PASSWORD: ${DB_PASSWORD}
+            POSTGRES_USER: ${DB_USERNAME}
+            POSTGRES_DB: ${DB_DATABASE_NAME}
+            POSTGRES_INITDB_ARGS: '--data-checksums'
+        volumes:
+            # PostgreSQLデータの永続化
+            - immich-pgdata:/var/lib/postgresql/data
+        shm_size: 128mb
+        restart: unless-stopped
+        networks:
+            - proxy-network
+
+networks:
+    proxy-network:
+        driver: bridge
+        name: proxy-network
+
+volumes:
+    immich-pgdata:
+        name: immich-pgdata
+    immich-redis-data:
+        name: immich-redis-data
+    immich-ml-cache:
+        name: immich-ml-cache


### PR DESCRIPTION
- ghcr.ioのreleaseタグイメージを使用するよう設定
- ビルド設定を削除し、イメージのプルのみで動作
- READMEに本番環境デプロイ手順を追記