### PR TITLE
fix: リリースデプロイにcelery-worker/beat追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,13 +116,13 @@ jobs:
                   docker compose pull django-api frontend
 
                   echo ">>> コンテナを再作成中..."
-                  docker compose up -d django-api frontend
+                  docker compose up -d django-api celery-worker celery-beat frontend
 
                   echo ">>> 古いイメージを削除中..."
                   docker image prune -f
 
                   echo "✅ デプロイ完了"
-                  docker compose ps django-api frontend
+                  docker compose ps django-api celery-worker celery-beat frontend
                   DEPLOY_SCRIPT
 
     # リリースサマリー出力


### PR DESCRIPTION
## Summary
- release.ymlのデプロイステップで`docker compose up -d`にcelery-worker/celery-beatが含まれていなかった
- django-apiと同じイメージを使うため、pullは不要だがup -dでコンテナ再作成が必要

## Root cause
Celeryコンテナ追加時にリリースワークフローの更新が漏れていた

## Impact
デプロイ後もcelery-worker/beatが古いコードで動作し、廃止済みのHypothesis Agentが実行された