### PR TITLE
release: README を更新（LLM/LiteLLM/Langfuse つながり図）

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,93 +55,36 @@ LLM 呼び出しは LiteLLM Proxy 経由でプロバイダー非依存、観測�
 - **`resolve_prompt(ref, **vars)`**（ユーティリティ）
   Langfuse から取得してコンパイル、失敗時は `fallback_text` を Mustache 風に簡易置換。
 
-### 設定モデルの関係
+### admin 項目と外部サービスのつながり
 
 ```mermaid
-erDiagram
-    LangfusePromptRef {
-        string name PK "例: hn-agent-orchestrator-system"
-        string langfuse_prompt_name "Langfuse上の名前"
-        string label "production/staging"
-        text fallback_text "Langfuse不達時に使用"
-    }
-    LLMProviderConfig {
-        string name PK "例: Kimi K2.5 本番"
-        string model_alias "bedrock/moonshotai.kimi-k2.5 等"
-        string proxy_api_key "LiteLLM Virtual Key（暗号化）"
-    }
-    LLMServiceConfig {
-        string service_name PK "orchestrator / detective / talk"
-        int provider_config_id FK
-        int timeout
-    }
-    HNAgentConfig {
-        string name PK
-        int orchestrator_system_prompt_id FK
-        int orchestrator_user_prompt_id FK
-        int detective_system_prompt_id FK
-        int detective_user_prompt_id FK
-        int score_threshold
-        int front_page_limit
-    }
-    TalkConfig {
-        string name PK "morning / evening / ..."
-        int system_prompt_ref_id FK
-        int user_prompt_ref_id FK
-        bool use_weather
-        bool use_events
-        bool use_datetime
-    }
-    LLMServiceConfig ||--o{ LLMProviderConfig : "provider_config"
-    HNAgentConfig ||--o{ LangfusePromptRef : "4本のFK"
-    TalkConfig ||--o{ LangfusePromptRef : "2本のFK"
-```
-
-**読み方**: HN Agent と Talk は「LLM 接続」を `LLMServiceConfig.service_name` で共有し、「プロンプト」は独立した FK で指定する。LLM 接続とプロンプト管理が分離しているので、モデルを差し替えてもプロンプトは変わらない／プロンプトを差し替えてもモデル接続は変わらない。
-
-### ランタイム呼び出しフロー（Talk を例に）
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant C as Client
-    participant V as TalkSynthesizeView
-    participant S as TalkService
-    participant R as resolve_prompt
-    participant LPR as LangfusePromptRef<br/>(Django DB)
-    participant LF as Langfuse API
-    participant L as LLMClient<br/>(langfuse.openai.OpenAI)
-    participant LP as LiteLLM Proxy
-    participant P as LLM Provider<br/>(Bedrock / OpenAI / …)
-
-    C->>V: POST /talk/synthesize/ {"config_name":"morning"}
-    V->>S: synthesize(config)
-    Note over S: プレースホルダー用データを並列取得<br/>(weather / events / datetime)
-
-    S->>R: resolve_prompt(config.system_prompt_ref)
-    R->>LPR: name / label / fallback_text を参照
-    R->>LF: get_prompt(langfuse_prompt_name, label)
-    alt Langfuse 到達可
-        LF-->>R: prompt.compile() 済みテキスト
-    else 失敗 or 未インストール
-        R-->>R: fallback_text で置換
+flowchart LR
+    subgraph Admin["Django admin"]
+        Provider["LLM設定<br/>model_alias + Virtual Key"]
+        Service["LLMサービス設定<br/>orchestrator / detective / talk"]
+        Ref["Langfuseプロンプト参照<br/>langfuse_prompt_name + label"]
+        HN["HackerNews Agent設定"]
+        Talk["Talk Generator"]
     end
-    R-->>S: system_prompt
 
-    S->>R: resolve_prompt(config.user_prompt_ref, weather=..., events=..., datetime=...)
-    R-->>S: user_prompt
+    subgraph External["外部サービス"]
+        LiteLLM[("LiteLLM Proxy<br/>/v1/chat/completions")]
+        Langfuse[("Langfuse<br/>get_prompt(name, label)")]
+    end
 
-    S->>L: generate_text(prompt, system_prompt)
-    Note over L: get_llm_settings("talk") で<br/>LLMServiceConfig → LLMProviderConfig を解決
-    L->>LP: POST /chat/completions<br/>(model_alias, Virtual Key)
-    LP->>P: 実プロバイダーへルーティング
-    P-->>LP: 応答
-    LP-->>L: completion
-    L-->>LF: 自動トレース送信（generation span）
-    L-->>S: 生成テキスト
-    S-->>V: {greeting_text, audio_data?}
-    V-->>C: 200 OK
+    Service -->|provider_config| Provider
+    HN -->|4本のプロンプト参照| Ref
+    HN -.->|orchestrator / detective| Service
+    Talk -->|2本のプロンプト参照| Ref
+    Talk -.->|talk| Service
+
+    Provider ==>|Virtual Key + model_alias| LiteLLM
+    Ref ==>|名前とラベルで取得| Langfuse
 ```
+
+- **実線**（admin 内）: FK 参照
+- **破線**（admin 内）: `service_name` 経由の紐付け
+- **太線**（admin → 外部）: ランタイムで実際に叩く API
 
 ### Langfuse プロンプトの命名規約（運用）
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ## 概要
 
-Docker コンテナベースの Web アプリケーションです。
-React SPA フロントエンドと Django REST API バックエンドで構成されています。
+Docker コンテナベースの Web アプリケーションです。React SPA フロントエンドと Django REST API バックエンドで構成されています。
+LLM 呼び出しは LiteLLM Proxy 経由でプロバイダー非依存、観測とプロンプト管理は Langfuse に集約しています。
 本番環境のデプロイとリバースプロキシ（Traefik）は [internal.kagiyama.net](https://github.com/kagiyama-baking/internal.kagiyama.net) リポジトリ（Ansible）が管理します。
 
 ## サービス
@@ -16,20 +16,145 @@ React SPA フロントエンドと Django REST API バックエンドで構成�
 - 🐍 **Django API**: REST API で複数の機能を提供するバックエンドサーバ
     - 🔐 **User**: ユーザー認証・管理機能
     - **integrations/** - 外部サービス連携
-        - 🤖 **LLM**: OpenAI API 設定・クライアント（チャット補完 + Embedding生成）
+        - 🤖 **LLM**: LiteLLM Proxy 経由の LLM クライアント（プロバイダー非依存・Langfuse 自動トレース）
+        - 🔭 **Langfuse**: プロンプト管理モデル `LangfusePromptRef`（HN Agent / Talk が参照）
         - 🔗 **MS Graph**: Microsoft Graph API 設定・認証・クライアント
-        - ☁️ **OneDrive**: Microsoft OneDrive との統合機能（ファイルアップロード・管理）
+        - ☁️ **OneDrive**: Microsoft OneDrive との統合機能
         - 📅 **Outlook**: Outlook Calendar 予定取得機能
-        - 🔊 **TTS**: テキスト読み上げ機能（Style-BERT-VITS2 プロキシ）
-        - 🌤️ **Weather**: 気象庁天気予報 API（今日・明日・明後日の天気、気温、降水確率）
+        - 🔊 **TTS**: テキスト読み上げ（Style-BERT-VITS2 プロキシ）
+        - 🌤️ **Weather**: 気象庁天気予報 API
         - 📰 **HN**: Hacker News Algolia API クライアント
-        - 🔍 **Tavily**: Tavily Web検索 API クライアント
+        - 🔍 **Tavily**: Tavily Web 検索 API クライアント
         - 💬 **Slack**: Slack Incoming Webhook 通知クライアント
     - **features/** - ビジネス機能
-        - 🎙️ **Talk**: 会話生成 API（設定ベースの柔軟な会話生成、天気・予定・日時情報を選択可能、TTS 音声合成対応）
-        - 📁 **Media**: メディアファイル管理機能（画像フォーマット変換、ZIP→PDF変換）
-        - 🕵️ **HN Agent**: Hacker News 監視・分析エージェント（Watcher → Orchestrator → Memory/Detective/Hypothesis Agent → Slack通知）
-- 🎤 **Style-BERT-VITS2 API**: 高品質な日本語音声合成サービス（GPU対応）
+        - 🎙️ **Talk**: 会話生成 API（プリセットベース・天気/予定/日時プレースホルダー対応・TTS 統合）
+        - 📁 **Media**: メディア変換（画像フォーマット変換、ZIP → PDF）
+        - 🕵️ **HackerNews Agent**: HN 監視・分析エージェント（Watcher → Orchestrator → Detective → Slack 通知）
+- 🎤 **Style-BERT-VITS2 API**: 日本語音声合成サービス（GPU）
+
+## LLM / LiteLLM / Langfuse の関係
+
+このプロジェクトでは LLM 周辺を 3 つのレイヤに分離しています。
+
+| レイヤ | 責務 | 管理場所 |
+|---|---|---|
+| **LLM 接続** | 「どのモデルに、どの鍵で繋ぐか」 | Django admin の「LLM設定」「LLMサービス設定」 |
+| **プロンプト管理** | 「どのテキストを渡すか」 | Django admin の「Langfuseプロンプト参照」+ Langfuse UI |
+| **機能設定** | 「いつ・どのプロンプトで呼ぶか」 | Django admin の「HackerNews Agent設定」「Talk Generator」 |
+
+### 構成要素
+
+- **LiteLLM Proxy**（外部サービス / internal.kagiyama.net 管理）
+  OpenAI 互換エンドポイントで、`model_alias`（例: `bedrock/moonshotai.kimi-k2.5`）を受けて実プロバイダーへルーティング。モデル差し替え・コスト集計・Virtual Key 発行を一元化。
+- **Langfuse**（外部サービス / SaaS or self-hosted）
+  LLM 呼び出しの観測（traces / generations / spans）と、バージョン管理付きのプロンプトテンプレート（`prompt.compile(**vars)`）を提供。
+- **`LLMProviderConfig`** / **`LLMServiceConfig`**（Django DB）
+  モデルエイリアス + Virtual Key をサービスごと（`orchestrator` / `detective` / `talk`）に割り当て。
+- **`LangfusePromptRef`**（Django DB）
+  Django 内識別名 ↔ Langfuse プロンプト名のマッピング + `fallback_text`。各機能（`HNAgentConfig` / `TalkConfig`）から FK で参照。
+- **`resolve_prompt(ref, **vars)`**（ユーティリティ）
+  Langfuse から取得してコンパイル、失敗時は `fallback_text` を Mustache 風に簡易置換。
+
+### 設定モデルの関係
+
+```mermaid
+erDiagram
+    LangfusePromptRef {
+        string name PK "例: hn-agent-orchestrator-system"
+        string langfuse_prompt_name "Langfuse上の名前"
+        string label "production/staging"
+        text fallback_text "Langfuse不達時に使用"
+    }
+    LLMProviderConfig {
+        string name PK "例: Kimi K2.5 本番"
+        string model_alias "bedrock/moonshotai.kimi-k2.5 等"
+        string proxy_api_key "LiteLLM Virtual Key（暗号化）"
+    }
+    LLMServiceConfig {
+        string service_name PK "orchestrator / detective / talk"
+        int provider_config_id FK
+        int timeout
+    }
+    HNAgentConfig {
+        string name PK
+        int orchestrator_system_prompt_id FK
+        int orchestrator_user_prompt_id FK
+        int detective_system_prompt_id FK
+        int detective_user_prompt_id FK
+        int score_threshold
+        int front_page_limit
+    }
+    TalkConfig {
+        string name PK "morning / evening / ..."
+        int system_prompt_ref_id FK
+        int user_prompt_ref_id FK
+        bool use_weather
+        bool use_events
+        bool use_datetime
+    }
+    LLMServiceConfig ||--o{ LLMProviderConfig : "provider_config"
+    HNAgentConfig ||--o{ LangfusePromptRef : "4本のFK"
+    TalkConfig ||--o{ LangfusePromptRef : "2本のFK"
+```
+
+**読み方**: HN Agent と Talk は「LLM 接続」を `LLMServiceConfig.service_name` で共有し、「プロンプト」は独立した FK で指定する。LLM 接続とプロンプト管理が分離しているので、モデルを差し替えてもプロンプトは変わらない／プロンプトを差し替えてもモデル接続は変わらない。
+
+### ランタイム呼び出しフロー（Talk を例に）
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant V as TalkSynthesizeView
+    participant S as TalkService
+    participant R as resolve_prompt
+    participant LPR as LangfusePromptRef<br/>(Django DB)
+    participant LF as Langfuse API
+    participant L as LLMClient<br/>(langfuse.openai.OpenAI)
+    participant LP as LiteLLM Proxy
+    participant P as LLM Provider<br/>(Bedrock / OpenAI / …)
+
+    C->>V: POST /talk/synthesize/ {"config_name":"morning"}
+    V->>S: synthesize(config)
+    Note over S: プレースホルダー用データを並列取得<br/>(weather / events / datetime)
+
+    S->>R: resolve_prompt(config.system_prompt_ref)
+    R->>LPR: name / label / fallback_text を参照
+    R->>LF: get_prompt(langfuse_prompt_name, label)
+    alt Langfuse 到達可
+        LF-->>R: prompt.compile() 済みテキスト
+    else 失敗 or 未インストール
+        R-->>R: fallback_text で置換
+    end
+    R-->>S: system_prompt
+
+    S->>R: resolve_prompt(config.user_prompt_ref, weather=..., events=..., datetime=...)
+    R-->>S: user_prompt
+
+    S->>L: generate_text(prompt, system_prompt)
+    Note over L: get_llm_settings("talk") で<br/>LLMServiceConfig → LLMProviderConfig を解決
+    L->>LP: POST /chat/completions<br/>(model_alias, Virtual Key)
+    LP->>P: 実プロバイダーへルーティング
+    P-->>LP: 応答
+    LP-->>L: completion
+    L-->>LF: 自動トレース送信（generation span）
+    L-->>S: 生成テキスト
+    S-->>V: {greeting_text, audio_data?}
+    V-->>C: 200 OK
+```
+
+### Langfuse プロンプトの命名規約（運用）
+
+| 用途 | Langfuse プロンプト名 |
+|---|---|
+| HN Agent Orchestrator system | `hn-agent-orchestrator` |
+| HN Agent Orchestrator user | `hn-agent-orchestrator-user` |
+| HN Agent Detective system | `hn-agent-detective` |
+| HN Agent Detective user | `hn-agent-detective-user` |
+| Talk system | `talk-{config_name}-system` |
+| Talk user | `talk-{config_name}-user` |
+
+Langfuse 未登録でも `LangfusePromptRef.fallback_text` があれば動作します。登録すると Langfuse UI 上でバージョン管理・A/B テスト・staging/production ラベル切り替えが可能になります。
 
 ## 特徴
 
@@ -39,7 +164,8 @@ React SPA フロントエンドと Django REST API バックエンドで構成�
 - 🔐 **ビルド証明**: SLSA Build Provenance による信頼性の担保
 - 📋 **SBOM**: ソフトウェア部品表（CycloneDX）の自動生成
 - 🛡️ **脆弱性スキャン**: Trivy によるイメージ検査
-- 🔒 **暗号化**: 機密情報の暗号化保存（OneDrive 設定など）
+- 🔒 **暗号化**: 機密情報の暗号化保存（MS Graph 秘密鍵、LiteLLM Virtual Key など）
+- 🔭 **LLM 観測**: Langfuse によるトレース・プロンプトバージョニング
 - ✅ **テスト**: pytest（バックエンド）+ Vitest + Playwright（フロントエンド）
 
 ## プロジェクト構成
@@ -49,53 +175,44 @@ kawashiro-server/
 ├── docker-compose.yml          # 開発用のDocker Compose設定
 ├── README.md                   # このファイル
 │
-├── .github/                    # GitHub設定
-│   └── workflows/              # GitHub Actionsワークフロー
-│       ├── build.yml           # ビルド・プッシュ（develop）
-│       ├── release.yml         # リリースタグ付け（main）
-│       ├── pr-checks.yml       # PRチェック
-│       └── cleanup-images.yml  # 古いイメージのクリーンアップ
+├── .github/workflows/          # GitHub Actionsワークフロー
+│   ├── build.yml               # ビルド・プッシュ（develop）
+│   ├── release.yml             # リリースタグ付け（main）
+│   ├── pr-checks.yml           # PRチェック
+│   └── cleanup-images.yml      # 古いイメージのクリーンアップ
 │
 ├── frontend/                   # React SPA フロントエンド
-│   ├── Dockerfile              # マルチステージビルド（node → nginx）
-│   ├── nginx.conf              # SPA配信 + APIプロキシ
-│   ├── package.json            # 依存関係（pnpm）
+│   ├── Dockerfile              # マルチステージ（node → nginx）
 │   ├── src/
 │   │   ├── components/         # UIコンポーネント
 │   │   ├── features/           # 画面（home, login, tts, talk, media）
 │   │   ├── lib/                # APIクライアント
-│   │   ├── stores/             # Zustand ストア
-│   │   └── types/              # 型定義
+│   │   └── stores/             # Zustand ストア
 │   ├── tests/                  # Vitest ユニットテスト
 │   └── e2e/                    # Playwright E2E テスト
 │
 ├── django_api/                 # Django REST API
-│   ├── Dockerfile              # Python 3.13-alpine ベース
-│   ├── pyproject.toml          # Python依存関係（uv使用）
-│   ├── django_api/             # メインプロジェクト設定
-│   ├── core/                   # コアアプリ（カスタムUserモデル、暗号化）
+│   ├── django_api/             # プロジェクト設定
+│   ├── core/                   # コアアプリ（Userモデル、暗号化、admin並び制御）
 │   ├── user/                   # ユーザー認証アプリ
-│   ├── health/                 # ヘルスチェックアプリ
-│   ├── integrations/           # 外部サービス連携
-│   │   ├── llm/                # LLM設定・クライアント（OpenAI API）
-│   │   ├── msgraph/            # Microsoft Graph API設定・クライアント
-│   │   ├── onedrive/           # OneDrive連携API
-│   │   ├── outlook/            # Outlook Calendar連携API
-│   │   ├── tts/                # TTS読み上げ（sbv2-apiプロキシ）
+│   ├── integrations/
+│   │   ├── llm/                # LLMProviderConfig / LLMServiceConfig / LLMClient
+│   │   ├── langfuse/           # LangfusePromptRef / resolve_prompt
+│   │   ├── msgraph/            # Microsoft Graph 設定・クライアント
+│   │   ├── onedrive/           # OneDrive 連携 API
+│   │   ├── outlook/            # Outlook Calendar 連携 API
+│   │   ├── tts/                # TTS 読み上げ
 │   │   ├── weather/            # 気象庁天気予報
-│   │   ├── hn/                 # Hacker News Algolia APIクライアント
-│   │   ├── tavily/             # Tavily Web検索APIクライアント
-│   │   └── slack/              # Slack Incoming Webhook通知
-│   ├── features/               # ビジネス機能
-│   │   ├── talk/               # 会話生成（LLM + 天気 + 予定 + TTS統合）
-│   │   ├── media/              # 画像処理（ZIP→PDF変換、画像形式変換）
-│   │   └── hn_agent/           # HN監視・分析エージェント
+│   │   ├── hn/                 # Hacker News Algolia クライアント
+│   │   ├── tavily/             # Tavily Web 検索クライアント
+│   │   └── slack/              # Slack Incoming Webhook
+│   ├── features/
+│   │   ├── talk/               # Talk Generator（LLM + 天気 + 予定 + TTS）
+│   │   ├── media/              # メディア変換
+│   │   └── hn_agent/           # HackerNews Agent
 │   └── tests/                  # テストコード
 │
-└── sbv2_api/                   # Style-BERT-VITS2 APIサーバー（GPU）
-    ├── Dockerfile              # コンテナ定義（CUDA 11.8）
-    ├── server.py               # FastAPIサーバー
-    └── config.yml              # モデル設定
+└── sbv2_api/                   # Style-BERT-VITS2 APIサーバー（GPU / CUDA 11.8）
 ```
 
 ## 必要な環境
@@ -103,6 +220,9 @@ kawashiro-server/
 - Docker Engine 20.10.0+
 - Docker Compose 2.0.0+
 - NVIDIA GPU + [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)（sbv2-api 用）
+- 外部サービス
+  - LiteLLM Proxy エンドポイント（`LITELLM_PROXY_URL`）
+  - Langfuse SaaS or self-hosted（`LANGFUSE_BASE_URL` など任意）
 
 ## インストール・セットアップ
 
@@ -124,154 +244,106 @@ nano django_api/.env
 
 ```bash
 sudo mkdir -p /opt/app/django-api/staticfiles
-sudo touch /opt/app/django-api/db.sqlite3
 sudo chown -R $USER:$USER /opt/app/
 ```
 
 ### 4. サーバーの起動
 
 ```bash
-# すべてのサービスを起動
 docker compose up -d
-
-# ログを確認
 docker compose logs -f
 ```
 
 ### 5. 動作確認
 
 ```bash
-# Django API ヘルスチェック
-curl http://localhost:8000/health/
-
-# フロントエンド（Docker）
-curl http://localhost:3000/
-
-# フロントエンド（開発サーバー）
-cd frontend && pnpm install && pnpm dev
-# http://localhost:5173/ でアクセス
+curl http://localhost:8000/health/    # Django API
+curl http://localhost:3000/           # Frontend
 ```
 
 ## 環境変数設定
 
-### Django API 設定
+`django_api/.env` に以下を設定します（`.env.sample` 参照）。
 
-`django_api/.env` ファイルに以下の環境変数を設定してください（`.env.sample` を参照）：
+| カテゴリ | 変数 | 説明 |
+|---|---|---|
+| Django | `SECRET_KEY` | 必須 |
+| Django | `DEBUG` | デフォルト `False` |
+| Django | `ALLOWED_HOSTS` | カンマ区切り、デフォルト `localhost` |
+| Django | `ENCRYPTION_KEY` | DB 内機密情報の暗号化（MS Graph 秘密鍵、LiteLLM Virtual Key 等） |
+| Django | `CSRF_TRUSTED_ORIGINS` | 本番時に Traefik 経由のドメインを指定 |
+| DB | `DB_ENGINE` / `DB_*` | PostgreSQL 接続情報 |
+| Celery | `CELERY_BROKER_URL` / `CELERY_RESULT_BACKEND` | デフォルト `redis://redis:6379/0` |
+| TTS | `TTS_SERVICE_URL` | デフォルト `http://sbv2-api:5000` |
+| LLM | `LITELLM_PROXY_URL` | LiteLLM Proxy のベース URL（例: `http://litellm-proxy:4000/v1`） |
+| LLM | `LITELLM_MASTER_KEY` | LLMProviderConfig.proxy_api_key が未設定時のフォールバック |
+| Langfuse | `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` | Langfuse 認証（任意。未設定時はトレース・プロンプト取得を skip） |
+| Langfuse | `LANGFUSE_BASE_URL` | self-hosted 使用時のみ（未指定時はクラウド） |
+| Langfuse | `LANGFUSE_TRACING_ENVIRONMENT` | `dev` / `prd` |
 
-```bash
-# Django設定（必須）
-SECRET_KEY=YOUR_SECRET_KEY
-
-# デバッグモード（デフォルト: False）
-DEBUG=False
-
-# 許可ホスト（カンマ区切り、デフォルト: localhost）
-ALLOWED_HOSTS=localhost,127.0.0.1
-
-# データベースに保存する機密情報の暗号化に使用
-ENCRYPTION_KEY=YOUR_ENCRYPTION_KEY
-
-# Style-BERT-VITS2 API（デフォルト: http://sbv2-api:5000）
-TTS_SERVICE_URL=http://sbv2-api:5000
-
-# リバースプロキシ経由時のCSRF信頼済みオリジン（本番環境用）
-CSRF_TRUSTED_ORIGINS=https://api.example.com
-```
-
-その他の設定（Microsoft Graph API、OpenAI API キーなど）は Django 管理画面（`/admin/`）から設定します。
+> **Note:** OpenAI / Bedrock 等の**プロバイダー側 API キー**は LiteLLM Proxy 側で管理します。Django 側では LiteLLM Virtual Key のみを扱います（`LLMProviderConfig.proxy_api_key`）。
 
 ## 使用方法
 
 ### サービスの管理
 
 ```bash
-# サービスの起動
-docker compose up -d
-
-# サービスの停止
-docker compose down
-
-# サービスの再起動
-docker compose restart
-```
-
-### ログの確認
-
-```bash
-# 全サービスのログ
-docker compose logs -f
-
-# 特定のサービスのログ
-docker compose logs -f django-api
-docker compose logs -f frontend
+docker compose up -d                # 起動
+docker compose down                 # 停止
+docker compose restart              # 再起動
+docker compose logs -f django-api   # ログ追跡
 ```
 
 ## CI/CD
 
 ### デプロイメントパイプライン
 
-本プロジェクトでは、GitHub Actions を活用した 3 段階のデプロイメントパイプラインを構築しています。
-本番デプロイは [internal.kagiyama.net](https://github.com/kagiyama-baking/internal.kagiyama.net)（Ansible）が担当します。
-
-### GitHub Actions ワークフロー
+GitHub Actions による 3 段階パイプライン。本番デプロイは [internal.kagiyama.net](https://github.com/kagiyama-baking/internal.kagiyama.net)（Ansible）が担当します。
 
 ```mermaid
 flowchart LR
-
-  %% 開発フェーズ（PR → develop）
   subgraph Dev["開発フェーズ"]
     direction TB
     A[feature/* ブランチ<br/>push & PR]
     B[PR to develop]
     C[pr-checks.yml<br/>━━━━━━━━━━<br/>・Dockerfile セキュリティスキャン<br/>・Django: Ruff lint/format<br/>・Django: pytest（カバレッジ80%以上）<br/>・Frontend: ESLint/Prettier/TypeScript<br/>・Frontend: Vitest（カバレッジ80%以上）<br/>・コンテナ統合テスト]
     D[develop へマージ]
-
-    A --> B
-    B --> C
-    C --> D
+    A --> B --> C --> D
   end
-
-  %% ステージング（develop push）
   subgraph Stg["ステージング"]
     direction TB
     E[develop push]
     F[build.yml<br/>━━━━━━━━━━<br/>・Multi-arch build<br/>・GHCR へ push<br/>・タグ: staging<br/>・SBOM生成]
-
     E --> F
   end
-
-  %% リリース（main push）
   subgraph Rel["リリース"]
     direction TB
     G[develop → main]
     H[release.yml<br/>━━━━━━━━━━<br/>・イメージ確認<br/>・staging → release リタグ]
-
     G --> H
   end
-
-  %% フェーズ間の接続
   Dev -.->|develop branch| Stg
   Stg -.->|staging images| Rel
 ```
 
 ### ビルド対象サービス
 
-| サービス     | PRチェック | ビルド・プッシュ | リリース |
-| ------------ | ---------- | ---------------- | -------- |
-| django-api   | ✓          | ✓                | ✓        |
-| frontend     | ✓          | ✓                | ✓        |
-| sbv2-api     | スキャンのみ | -              | -        |
+| サービス | PR チェック | ビルド・プッシュ | リリース |
+|---|---|---|---|
+| django-api | ✓ | ✓ | ✓ |
+| frontend | ✓ | ✓ | ✓ |
+| sbv2-api | スキャンのみ | - | - |
 
-> **Note:** `sbv2-api` は NVIDIA GPU が必須のため、CI 環境ではビルド・テストを実行しません。Dockerfileのセキュリティスキャンのみ行います。
+> **Note:** `sbv2-api` は NVIDIA GPU 必須のため CI 環境ではビルドしません。Dockerfile のセキュリティスキャンのみ実施。
 
 ### コンテナイメージのタグ戦略
 
-| タグ           | 用途             | 更新タイミング                 |
-| -------------- | ---------------- | ------------------------------ |
-| `staging`      | ステージング環境 | develop ブランチへのプッシュ時 |
-| `release`      | 本番環境         | main ブランチへのマージ時      |
-| `latest`       | 最新版（互換性） | main ブランチへのマージ時      |
-| `sha-<commit>` | 特定バージョン   | 各ビルド時                     |
+| タグ | 用途 | 更新タイミング |
+|---|---|---|
+| `staging` | ステージング環境 | develop ブランチ push |
+| `release` | 本番環境 | main ブランチマージ |
+| `latest` | 最新版（互換性） | main ブランチマージ |
+| `sha-<commit>` | 特定バージョン | 各ビルド |
 
 ## テストの実行
 
@@ -289,44 +361,45 @@ uv run pytest tests/ -v --tb=short \
 ```bash
 cd frontend
 pnpm test:ci       # ユニットテスト（カバレッジ付き）
-pnpm test:e2e      # E2Eテスト（Playwright）
+pnpm test:e2e      # E2E テスト（Playwright）
 ```
 
 ## 技術スタック
 
 ### フロントエンド
 
-- **React 19**: UI ライブラリ
-- **Vite**: ビルドツール
-- **TypeScript**: 型安全な JavaScript
-- **Tailwind CSS v4**: ユーティリティファースト CSS
-- **shadcn/ui**: UI コンポーネントライブラリ
-- **Zustand**: 状態管理
-- **ky**: HTTP クライアント
+- **React 19** / **Vite** / **TypeScript**
+- **Tailwind CSS v4** / **shadcn/ui**
+- **Zustand**（状態管理） / **ky**（HTTP）
 
 ### バックエンド
 
-- **Django 6.0**: Python Web フレームワーク
-- **Django REST Framework**: REST API 構築
-- **PostgreSQL 17**: リレーショナルデータベース（pgvector拡張対応）
-- **Celery + Redis**: 非同期タスクキュー・定期タスクスケジューラ
-- **uv**: 高速 Python パッケージマネージャー
+- **Django 6.0** + **Django REST Framework**
+- **PostgreSQL 17**（pgvector 拡張対応）
+- **Celery + Redis**（非同期・定期タスク）
+- **uv**（高速 Python パッケージマネージャ）
+
+### LLMOps
+
+- **LiteLLM Proxy**（OpenAI 互換 + モデルルーティング）
+- **LangChain / LangGraph**（HN Agent Orchestrator の ReAct Agent）
+- **Langfuse**（トレース + プロンプト管理）
 
 ### インフラ・DevOps
 
-- **Docker & Docker Compose**: コンテナ化とオーケストレーション
-- **nginx**: フロントエンド配信 + API プロキシ
-- **Traefik**: リバースプロキシ（internal.kagiyama.net で管理）
-- **GitHub Actions**: CI/CD パイプライン
-- **GitHub Container Registry**: コンテナイメージレジストリ
-- **Trivy**: コンテナセキュリティスキャナー
+- **Docker & Docker Compose**
+- **nginx**（フロント配信 + API プロキシ）
+- **Traefik**（リバースプロキシ / Ansible 側管理）
+- **GitHub Actions** / **GitHub Container Registry**
+- **Trivy**（セキュリティスキャナ）
 
 ### 外部サービス連携
 
-- **Microsoft Graph API**: OneDrive/Outlook 連携
-- **OpenAI API**: チャット補完・Embedding生成
-- **気象庁天気予報 API**: 天気予報データ取得
-- **Style-BERT-VITS2**: 高品質日本語音声合成エンジン（CUDA 11.8）
-- **Hacker News Algolia API**: HNスレッド・コメント取得
-- **Tavily API**: Web検索（HN Agent背景調査）
-- **Slack Incoming Webhook**: 調査結果通知
+- **Microsoft Graph API**（OneDrive / Outlook）
+- **LiteLLM Proxy**（LLM 呼び出しの共通入口）
+- **Langfuse**（観測 / プロンプト管理）
+- **気象庁天気予報 API**
+- **Style-BERT-VITS2**（音声合成・CUDA 11.8）
+- **Hacker News Algolia API**
+- **Tavily API**（Web 検索）
+- **Slack Incoming Webhook**（通知）

--- a/django_api/README.md
+++ b/django_api/README.md
@@ -31,84 +31,31 @@ LLM 周辺を 3 レイヤに分け、それぞれ Django admin で独立して�
 
 **原則**: プロンプトとモデル接続が独立しているため、モデル差し替え（例: GPT-4o → Kimi K2.5）を行っても Langfuse 上のプロンプトは不変、プロンプト改修に Django 再デプロイは不要です。
 
-### LLM 呼び出しのデータフロー
+### admin 項目と外部サービスのつながり
 
 ```mermaid
 flowchart LR
-    subgraph Django["Django API（自前コード）"]
-        HNConfig["HNAgentConfig<br/>(4 FKs)"]
-        TalkConfig["TalkConfig<br/>(2 FKs)"]
-        Resolve["resolve_prompt()<br/>integrations/langfuse/client.py"]
-        Client["LLMClient<br/>langfuse.openai.OpenAI"]
-    end
-
-    subgraph DB["Django admin DB"]
-        LPR[("LangfusePromptRef<br/>name / label / fallback")]
-        Provider[("LLMProviderConfig<br/>model_alias / Virtual Key")]
-        Service[("LLMServiceConfig<br/>service_name → provider")]
+    subgraph Admin["Django admin"]
+        Provider["LLM設定<br/>model_alias + Virtual Key"]
+        Service["LLMサービス設定<br/>orchestrator / detective / talk"]
+        Ref["Langfuseプロンプト参照<br/>langfuse_prompt_name + label"]
+        HN["HackerNews Agent設定"]
+        Talk["Talk Generator"]
     end
 
     subgraph External["外部サービス"]
-        LF[("Langfuse<br/>プロンプト+観測")]
-        Proxy[("LiteLLM Proxy<br/>OpenAI 互換")]
-        LLM[("LLM Provider<br/>Bedrock / OpenAI …")]
+        LiteLLM[("LiteLLM Proxy<br/>/v1/chat/completions")]
+        Langfuse[("Langfuse<br/>get_prompt(name, label)")]
     end
 
-    HNConfig -->|4 FKs| LPR
-    TalkConfig -->|2 FKs| LPR
+    Service -->|provider_config| Provider
+    HN -->|4本のプロンプト参照| Ref
+    HN -.->|orchestrator / detective| Service
+    Talk -->|2本のプロンプト参照| Ref
+    Talk -.->|talk| Service
 
-    HNConfig -.->|プロンプト解決| Resolve
-    TalkConfig -.->|プロンプト解決| Resolve
-    Resolve --> LPR
-    Resolve <-->|get_prompt / compile| LF
-
-    HNConfig -.->|LLM 呼び出し| Client
-    TalkConfig -.->|LLM 呼び出し| Client
-    Client --> Service --> Provider
-    Client -->|HTTPS| Proxy
-    Proxy --> LLM
-    Client -.->|自動トレース| LF
-```
-
-### ランタイムシーケンス（Talk を例に）
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant C as Client
-    participant V as TalkSynthesizeView
-    participant S as TalkService
-    participant R as resolve_prompt
-    participant DB as Django DB
-    participant LF as Langfuse API
-    participant L as LLMClient
-    participant P as LiteLLM Proxy
-
-    C->>V: POST /talk/synthesize/ {"config_name":"morning"}
-    V->>S: synthesize(config)
-    Note over S: 有効プレースホルダのデータを並列取得<br/>(weather / events / datetime)
-
-    S->>R: resolve_prompt(config.system_prompt_ref)
-    R->>DB: ref.langfuse_prompt_name / label / fallback_text
-    R->>LF: get_prompt(name, label)
-    alt Langfuse 到達可
-        LF-->>R: compiled prompt
-    else 失敗
-        R-->>R: fallback_text で変数置換
-    end
-    R-->>S: system_prompt
-
-    S->>R: resolve_prompt(config.user_prompt_ref, weather=..., events=..., datetime=...)
-    R-->>S: user_prompt
-
-    S->>L: generate_text(prompt, system_prompt)
-    Note over L: get_llm_settings("talk") で<br/>LLMServiceConfig → LLMProviderConfig 解決
-    L->>P: POST /chat/completions<br/>(model_alias, Virtual Key)
-    P-->>L: completion
-    L-->>LF: generation span 自動送信
-    L-->>S: 生成テキスト
-    S-->>V: {greeting_text, audio_data?}
-    V-->>C: 200 OK
+    Provider ==>|Virtual Key + model_alias| LiteLLM
+    Ref ==>|名前とラベルで取得| Langfuse
 ```
 
 ## セットアップ

--- a/django_api/README.md
+++ b/django_api/README.md
@@ -1,37 +1,134 @@
 # Django API
 
-REST API で複数の機能を提供するバックエンドサーバです。
+REST API で複数の機能を提供するバックエンドサーバです。LLM 呼び出しは LiteLLM Proxy に集約し、観測とプロンプト管理は Langfuse に統一しています。
 
 ## 機能一覧
 
-| アプリ   | エンドポイント | 説明                                                   |
-| -------- | -------------- | ------------------------------------------------------ |
-| user     | `/user/`       | ユーザー認証・管理                                     |
-| onedrive | `/onedrive/`   | OneDrive ファイルアップロード・管理                    |
-| outlook  | `/outlook/`    | Outlook Calendar 予定取得                              |
-| media    | `/media/`      | メディアファイル管理（画像変換・ZIP→PDF）              |
-| tts      | `/tts/`        | テキスト読み上げ（Style-BERT-VITS2 プロキシ）          |
-| weather  | `/weather/`    | 気象庁天気予報                                         |
-| talk     | `/talk/`       | 会話生成（設定ベースの AI 会話生成・TTS 対応）         |
-| hn_agent | `/hn-agent/`   | HN監視・分析エージェント（Watcher・調査・結果閲覧）    |
+| アプリ | エンドポイント | 説明 |
+|---|---|---|
+| user | `/user/` | ユーザー認証・管理 |
+| onedrive | `/onedrive/` | OneDrive ファイル連携 |
+| outlook | `/outlook/` | Outlook Calendar 予定取得 |
+| media | `/media/` | 画像変換・ZIP→PDF |
+| tts | `/tts/` | テキスト読み上げ（Style-BERT-VITS2 プロキシ） |
+| weather | `/weather/` | 気象庁天気予報 |
+| talk | `/talk/` | 会話生成（Talk Generator） |
+| hn-agent | `/hn-agent/` | HackerNews Agent（監視・調査） |
+
+## アーキテクチャの肝
+
+### 責務分離: LLM 接続 / プロンプト管理 / 機能設定
+
+LLM 周辺を 3 レイヤに分け、それぞれ Django admin で独立して管理します。
+
+| レイヤ | モデル | 管理画面 | 役割 |
+|---|---|---|---|
+| LLM 接続 | `LLMProviderConfig` | 「LLM設定」 | モデルエイリアス + LiteLLM Virtual Key |
+| LLM 接続 | `LLMServiceConfig` | 「LLMサービス設定」 | `orchestrator` / `detective` / `talk` にプロバイダ割り当て + タイムアウト |
+| プロンプト管理 | `LangfusePromptRef` | 「Langfuseプロンプト参照」 | Langfuse プロンプト名 + ラベル + フォールバック |
+| 機能設定 | `HNAgentConfig` | 「HackerNews Agent設定」 | 閾値、ポーリング、取得件数、使用プロンプト 4 本 |
+| 機能設定 | `TalkConfig` | 「Talk Generator」 | プリセットごとの動作パラメータ + 使用プロンプト 2 本 + TTS |
+
+**原則**: プロンプトとモデル接続が独立しているため、モデル差し替え（例: GPT-4o → Kimi K2.5）を行っても Langfuse 上のプロンプトは不変、プロンプト改修に Django 再デプロイは不要です。
+
+### LLM 呼び出しのデータフロー
+
+```mermaid
+flowchart LR
+    subgraph Django["Django API（自前コード）"]
+        HNConfig["HNAgentConfig<br/>(4 FKs)"]
+        TalkConfig["TalkConfig<br/>(2 FKs)"]
+        Resolve["resolve_prompt()<br/>integrations/langfuse/client.py"]
+        Client["LLMClient<br/>langfuse.openai.OpenAI"]
+    end
+
+    subgraph DB["Django admin DB"]
+        LPR[("LangfusePromptRef<br/>name / label / fallback")]
+        Provider[("LLMProviderConfig<br/>model_alias / Virtual Key")]
+        Service[("LLMServiceConfig<br/>service_name → provider")]
+    end
+
+    subgraph External["外部サービス"]
+        LF[("Langfuse<br/>プロンプト+観測")]
+        Proxy[("LiteLLM Proxy<br/>OpenAI 互換")]
+        LLM[("LLM Provider<br/>Bedrock / OpenAI …")]
+    end
+
+    HNConfig -->|4 FKs| LPR
+    TalkConfig -->|2 FKs| LPR
+
+    HNConfig -.->|プロンプト解決| Resolve
+    TalkConfig -.->|プロンプト解決| Resolve
+    Resolve --> LPR
+    Resolve <-->|get_prompt / compile| LF
+
+    HNConfig -.->|LLM 呼び出し| Client
+    TalkConfig -.->|LLM 呼び出し| Client
+    Client --> Service --> Provider
+    Client -->|HTTPS| Proxy
+    Proxy --> LLM
+    Client -.->|自動トレース| LF
+```
+
+### ランタイムシーケンス（Talk を例に）
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant V as TalkSynthesizeView
+    participant S as TalkService
+    participant R as resolve_prompt
+    participant DB as Django DB
+    participant LF as Langfuse API
+    participant L as LLMClient
+    participant P as LiteLLM Proxy
+
+    C->>V: POST /talk/synthesize/ {"config_name":"morning"}
+    V->>S: synthesize(config)
+    Note over S: 有効プレースホルダのデータを並列取得<br/>(weather / events / datetime)
+
+    S->>R: resolve_prompt(config.system_prompt_ref)
+    R->>DB: ref.langfuse_prompt_name / label / fallback_text
+    R->>LF: get_prompt(name, label)
+    alt Langfuse 到達可
+        LF-->>R: compiled prompt
+    else 失敗
+        R-->>R: fallback_text で変数置換
+    end
+    R-->>S: system_prompt
+
+    S->>R: resolve_prompt(config.user_prompt_ref, weather=..., events=..., datetime=...)
+    R-->>S: user_prompt
+
+    S->>L: generate_text(prompt, system_prompt)
+    Note over L: get_llm_settings("talk") で<br/>LLMServiceConfig → LLMProviderConfig 解決
+    L->>P: POST /chat/completions<br/>(model_alias, Virtual Key)
+    P-->>L: completion
+    L-->>LF: generation span 自動送信
+    L-->>S: 生成テキスト
+    S-->>V: {greeting_text, audio_data?}
+    V-->>C: 200 OK
+```
 
 ## セットアップ
 
 ### 1. 環境変数の設定
 
-`.env.sample` を参考に `.env` ファイルを作成してください：
+`.env.sample` を参考に `.env` を作成：
 
 ```bash
 cp .env.sample .env
 ```
 
 ```env
-# Django設定
+# Django
 SECRET_KEY=your-secret-key
 DEBUG=False
 ALLOWED_HOSTS=localhost,127.0.0.1
+ENCRYPTION_KEY=your-encryption-key
 
-# データベース設定（PostgreSQL）
+# DB
 DB_ENGINE=django.db.backends.postgresql
 DB_NAME=kawashiro
 DB_USER=kawashiro
@@ -39,168 +136,188 @@ DB_PASSWORD=kawashiro-dev
 DB_HOST=app-database
 DB_PORT=5432
 
-# 暗号化キー（データベースに保存する機密情報の暗号化に使用）
-ENCRYPTION_KEY=your-encryption-key
+# Celery
+CELERY_BROKER_URL=redis://redis:6379/0
 
-# Style-BERT-VITS2 API（音声合成機能）
+# TTS
 TTS_SERVICE_URL=http://sbv2-api:5000
+
+# LLM (LiteLLM Proxy)
+LITELLM_PROXY_URL=http://litellm-proxy:4000/v1
+LITELLM_MASTER_KEY=your-litellm-master-key
+
+# Langfuse (任意)
+LANGFUSE_PUBLIC_KEY=pk-lf-xxxx
+LANGFUSE_SECRET_KEY=sk-lf-xxxx
+LANGFUSE_BASE_URL=https://cloud.langfuse.com
+LANGFUSE_TRACING_ENVIRONMENT=dev
 ```
 
-> **Note:** OpenAI APIキー、Tavily APIキー、Slack Webhook URL等の機密情報はDjango管理画面（`/admin/`）から設定します。環境変数では管理しません。
+> **Note:** プロバイダ側 API キー（OpenAI / Bedrock 等）は LiteLLM Proxy 側で管理します。Django 側は LiteLLM の Virtual Key（`LLMProviderConfig.proxy_api_key`、暗号化保存）のみを持ちます。
 
-### 2. マイグレーションの実行
+### 2. マイグレーション & 管理ユーザー作成
 
 ```bash
 uv run ./manage.py migrate
-```
-
-### 3. 管理ユーザーの作成
-
-```bash
 uv run ./manage.py createsuperuser
 ```
 
-### 4. サーバーの起動
+### 3. サーバー起動
 
 ```bash
-# 開発環境
-uv run ./manage.py runserver
-
-# 本番環境（Docker）
-docker compose up -d django-api
+uv run ./manage.py runserver          # 開発
+docker compose up -d django-api        # Docker
 ```
 
 ## 管理画面での設定
 
-Django 管理画面（`http://localhost:8000/admin/`）で以下の設定を行います。
+Django 管理画面（`http://localhost:8000/admin/`）は 3 グループに整列されています。
 
-### Microsoft Graph API 設定（OneDrive/Outlook 機能）
+### 1. システム設定
 
-「MSGRAPH CONFIG」から以下を設定：
+`Core` / `認証と認可` / `認証トークン`
 
-| 項目               | 説明                                       |
-| ------------------ | ------------------------------------------ |
-| テナントID         | Azure AD テナント ID                       |
-| クライアントID     | Azure AD アプリケーション ID               |
-| 証明書サムプリント | 証明書のサムプリント                       |
-| 秘密鍵             | PEM 形式の秘密鍵（暗号化されて DB に保存） |
-| 対象ユーザー       | アクセス対象のユーザーメールアドレス       |
+### 2. 外部サービス設定
 
-### 会話生成設定（Talk 機能）
+#### Microsoft 365（OneDrive / Outlook 機能）
 
-「会話生成」→「会話生成設定」から複数の設定を登録できます：
+`Microsoft Graph API 設定` から：
 
-| 項目               | 説明                                               |
-| ------------------ | -------------------------------------------------- |
-| 設定名             | API 呼び出し時の識別子（例: `morning`, `evening`） |
-| 表示名             | 管理画面での表示名                                 |
-| 天気情報を使用     | `{{weather}}` プレースホルダーを有効化             |
-| 予定情報を使用     | `{{events}}` プレースホルダーを有効化              |
-| 日時情報を使用     | `{{datetime}}` プレースホルダーを有効化            |
-| 予報区コード       | 6 桁の数字（天気使用時のみ必須、例: `130010`）     |
-| システムプロンプト | AI のキャラクター設定                              |
-| TTS 有効           | 音声合成を有効にするか                             |
-| TTS 設定           | モデル名、スタイル、速度など                       |
+| 項目 | 説明 |
+|---|---|
+| テナント ID | Azure AD テナント ID |
+| クライアント ID | Azure AD アプリケーション ID |
+| 証明書サムプリント | 証明書のサムプリント |
+| 秘密鍵 | PEM 形式（暗号化保存） |
+| 対象ユーザー | アクセス対象のメールアドレス |
 
-#### API 呼び出し例
+#### Slack
+
+Incoming Webhook URL（暗号化保存）
+
+#### Tavily
+
+Tavily Web 検索の API キー（暗号化保存）
+
+#### Celery（Periodic Tasks）
+
+`django-celery-beat` の定期タスクスケジューラー。HN Agent のポーリングはここで有効化します。
+
+### 3. AI ツール設定
+
+#### LLM 設定（`LLMProviderConfig`）
+
+モデルエイリアス + LiteLLM Virtual Key の組み合わせを登録します。複数登録可能で、`LLMServiceConfig` から共有して参照できます。
+
+| 項目 | 説明 |
+|---|---|
+| 設定名 | 識別名（例: `Kimi K2.5 本番`, `GPT-4o テスト`） |
+| モデルエイリアス | LiteLLM Proxy の `model_name`（例: `bedrock/moonshotai.kimi-k2.5`） |
+| Virtual Key | LiteLLM Virtual Key（暗号化保存、未設定時は `LITELLM_MASTER_KEY` を使用） |
+
+#### LLM サービス設定（`LLMServiceConfig`）
+
+各サービス（`orchestrator` / `detective` / `talk`）にどの `LLMProviderConfig` を使うかを割り当てます。
+
+| 項目 | 説明 |
+|---|---|
+| サービス名 | `HN Agent Orchestrator` / `HN Agent Detective` / `Talk Generator` |
+| LLM 設定 | 使用する `LLMProviderConfig` を選択 |
+| 有効 | サービス設定を有効化 |
+| タイムアウト（秒） | API リクエストタイムアウト（デフォルト 60） |
+
+#### Langfuse プロンプト参照（`LangfusePromptRef`）
+
+Langfuse 上のプロンプトを Django 側で参照するためのマッピング。`HNAgentConfig` / `TalkConfig` から FK で選択します。
+
+| 項目 | 説明 |
+|---|---|
+| 識別名 | Django 内の unique 名（例: `talk-morning-system`） |
+| Langfuse プロンプト名 | Langfuse 上の実プロンプト名 |
+| ラベル | `production` / `staging`（Langfuse の version ラベル） |
+| フォールバックテキスト | Langfuse 不達時や未登録時に使用（`{{key}}` 変数は呼び出し側で置換） |
+
+初期データとして HN Agent 用 4 種（`hn-agent-orchestrator-system` / `-user`、`hn-agent-detective-system` / `-user`）が migration 0002 で自動投入されます。Talk 用は `TalkConfig` 作成時に自動生成されます。
+
+#### HackerNews Agent 設定（`HNAgentConfig`）
+
+| 項目 | 説明 |
+|---|---|
+| 有効 | この設定を有効化（1 つのみ） |
+| 推論深度 | Orchestrator の reasoning 量（low/medium/high/無効） |
+| スコア閾値 | 調査をトリガーするスコア（例: 100） |
+| 速度閾値 | 調査をトリガーするスコア上昇速度（ポイント/時間） |
+| ポーリング間隔（秒） | HN フロントページ取得の間隔（最低 60） |
+| フロントページ取得件数 | 1 回のポーリングで取得する件数（デフォルト 30、Algolia 経由で 90 以上も可） |
+| Orchestrator / Detective × system / user | 4 本の `LangfusePromptRef` FK |
+
+#### Talk Generator（`TalkConfig`）
+
+プリセットごとに複数登録可能（`morning` / `evening` / `welcome_home` …）。
+
+| 項目 | 説明 |
+|---|---|
+| 設定名 | API 呼び出し時の識別子（unique） |
+| 表示名 | 管理画面での表示名 |
+| 天気情報を使用 | `{{weather}}` プレースホルダーを有効化 |
+| 予定情報を使用 | `{{events}}` プレースホルダーを有効化 |
+| 日時情報を使用 | `{{datetime}}` プレースホルダーを有効化 |
+| 予報区コード | 6 桁の数字（天気使用時のみ必須、例: `130010`） |
+| TTS 設定 | 音声合成のモデル・スタイル・速度・フォーマット |
+| システムプロンプト | `system_prompt_ref` で `LangfusePromptRef` を選択 |
+| ユーザープロンプト | `user_prompt_ref` で `LangfusePromptRef` を選択 |
+
+##### API 呼び出し例
 
 ```bash
 # 設定一覧を取得
 curl http://localhost:8000/talk/configs/ \
   -H "Authorization: Token YOUR_TOKEN"
 
-# 会話生成
+# 会話生成（user_prompt はサーバー側管理のため不要）
 curl -X POST http://localhost:8000/talk/synthesize/ \
   -H "Authorization: Token YOUR_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{
-    "config_name": "morning",
-    "user_prompt": "{{datetime}}を踏まえて挨拶してください"
-  }'
+  -d '{"config_name": "morning"}'
 ```
 
-#### プレースホルダー
+##### プレースホルダー
 
-| プレースホルダー | 内容                 | 設定で有効化が必要 |
-| ---------------- | -------------------- | ------------------ |
-| `{{datetime}}`   | 日時・曜日・祝日情報 | 日時情報を使用     |
-| `{{weather}}`    | 天気予報データ       | 天気情報を使用     |
-| `{{events}}`     | 本日の予定データ     | 予定情報を使用     |
+Langfuse 上のユーザープロンプトテンプレートで以下のプレースホルダーが使用可能です（`TalkConfig` で有効化されている場合のみ値が渡される）。
 
-### OpenAI API 設定（LLM テキスト生成・Embedding）
+| プレースホルダー | 内容 | 設定 |
+|---|---|---|
+| `{{datetime}}` | 日時・曜日・祝日情報（JSON） | 日時情報を使用 |
+| `{{weather}}` | 天気予報データ（JSON） | 天気情報を使用 |
+| `{{events}}` | 本日の予定データ（JSON） | 予定情報を使用 |
 
-「OpenAI API設定」から以下を設定：
+### HackerNews Agent API
 
-| 項目              | 説明                                                    |
-| ----------------- | ------------------------------------------------------- |
-| 設定名            | この設定を識別するための名前                            |
-| 有効              | この設定を有効にする（1つだけ有効可）                   |
-| チャットモデル    | チャット補完に使用するモデル（例: `gpt-4o-mini`）       |
-| Embeddingモデル   | Embedding生成に使用するモデル（例: `text-embedding-3-small`）|
-| タイムアウト      | APIリクエストのタイムアウト秒数                          |
-| APIキー           | OpenAI APIキー（暗号化されてDBに保存）                   |
-
-### Tavily API 設定（Web検索・HN Agent背景調査）
-
-「Tavily API設定」から以下を設定：
-
-| 項目           | 説明                                   |
-| -------------- | -------------------------------------- |
-| 設定名         | この設定を識別するための名前           |
-| 有効           | この設定を有効にする（1つだけ有効可）  |
-| APIキー        | Tavily APIキー（暗号化されてDBに保存） |
-| タイムアウト   | APIリクエストのタイムアウト秒数        |
-
-### Slack 通知設定
-
-「Slack通知設定」から以下を設定：
-
-| 項目          | 説明                                          |
-| ------------- | --------------------------------------------- |
-| 設定名        | この設定を識別するための名前                  |
-| 有効          | この設定を有効にする（1つだけ有効可）         |
-| Webhook URL   | Slack Incoming Webhook URL（暗号化されてDBに保存）|
-
-### HN Agent 設定
-
-「HN Agent設定」から以下を設定：
-
-| 項目                  | 説明                                                |
-| --------------------- | --------------------------------------------------- |
-| Embedding次元数       | Embedding APIの出力次元数（small: 1536, large: 3072）|
-| スコア閾値            | 調査をトリガーするスコアの閾値                      |
-| 速度閾値              | 調査をトリガーするスコア上昇速度の閾値              |
-| 類似度閾値            | 過去スレッド検索のcosine similarity閾値（0-1）      |
-| ポーリング間隔        | HNフロントページのポーリング間隔（秒）              |
-
-### HN Agent API
-
-| メソッド | パス                              | 説明                                    |
-| -------- | --------------------------------- | --------------------------------------- |
-| `POST`   | `/hn-agent/run-all/`              | Watcher + Orchestrator一括実行          |
-| `POST`   | `/hn-agent/watcher/run/`          | Watcherのみ手動実行                     |
-| `POST`   | `/hn-agent/investigate/`          | 指定hn_idのスレッドをOrchestrator調査   |
-| `GET`    | `/hn-agent/threads/`              | 監視中スレッド一覧                      |
-| `GET`    | `/hn-agent/investigations/`       | 調査結果一覧                            |
-| `GET`    | `/hn-agent/investigations/<id>/`  | 調査結果の詳細                          |
+| メソッド | パス | 説明 |
+|---|---|---|
+| `POST` | `/hn-agent/run-all/` | Watcher + Orchestrator 一括実行 |
+| `POST` | `/hn-agent/watcher/run/` | Watcher のみ手動実行 |
+| `POST` | `/hn-agent/investigate/` | 指定 `hn_id` を Orchestrator 調査 |
+| `GET` | `/hn-agent/threads/` | 監視中スレッド一覧 |
 
 ## テストの実行
 
 ```bash
-# 全テスト実行（e2eテストを除く、カバレッジ付き）
+# 全テスト（e2e 除外、カバレッジ付き）
 uv run pytest tests/ -v --tb=short \
   --cov=user --cov=core --cov=integrations --cov=features \
   --cov-report=term-missing --cov-fail-under=80 -m "not e2e"
 
-# 特定のアプリのテスト
+# 特定のアプリのみ
 uv run pytest tests/features/talk/
-uv run pytest tests/user/
+uv run pytest tests/features/hn_agent/
+uv run pytest tests/integrations/langfuse/
 ```
 
 ## API ドキュメント
 
-Swagger UI でインタラクティブな API ドキュメントを確認できます：
-
-- **Swagger UI**: `http://localhost:8000/swagger/`
-- **ReDoc**: `http://localhost:8000/redoc/`
-- **OpenAPI スキーマ**: `http://localhost:8000/schema/`
+| UI | パス |
+|---|---|
+| Swagger UI | `http://localhost:8000/swagger/` |
+| ReDoc | `http://localhost:8000/redoc/` |
+| OpenAPI スキーマ | `http://localhost:8000/schema/` |

--- a/django_api/features/hn_agent/README.md
+++ b/django_api/features/hn_agent/README.md
@@ -1,188 +1,221 @@
-# HN Agent — Hacker News 監視・分析エージェント
+# HackerNews Agent — HN 監視・分析エージェント
 
 ## 目的
 
-Hacker News（HN）のフロントページを定期監視し、急上昇するスレッドを検出して**AIが自律的に調査・分析**するエージェントシステム。単なる要約ツールではなく、「なぜ急上昇しているか」「過去に同じ話題はあったか」「コミュニティ内で意見が割れているか」を自ら判断して調査し、結果をSlackに通知する。
+Hacker News のフロントページを定期監視し、急上昇するスレッドを検出して **AI が自律的に調査・分析**するエージェントシステム。「なぜ急上昇しているか」「コミュニティ内で意見が割れているか」を AI が判断して調査し、結果を Slack に通知します。
 
 ## 全体アーキテクチャ
 
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│ Celery Beat（定期実行）or API（手動実行）                            │
-└────────────────────┬────────────────────────────────────────────────┘
-                     ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│ Watcher（tasks.py: poll_front_page）                                │
-│ ・HN Algolia APIでフロントページをポーリング                        │
-│ ・スコア・コメント数のスナップショットを記録                        │
-│ ・スコア閾値超え or 上昇速度閾値超えのスレッドを検出               │
-└────────────────────┬────────────────────────────────────────────────┘
-                     ▼ 閾値超えスレッド毎に起動
-┌─────────────────────────────────────────────────────────────────────┐
-│ Orchestrator（orchestrator.py）                                     │
-│ ・OpenAI Function Callingループで自律的にAgentを呼び分ける          │
-│ ・LLMが「どのAgentを使うべきか」を判断する                         │
-│ ・最大10ステップで停止（無限ループ防止）                            │
-│                                                                     │
-│  ┌──────────────┐  ┌──────────────────┐                            │
-│  │ Memory Agent │  │ Detective Agent  │                            │
-│  │              │  │                  │                            │
-│  │ pgvectorで   │  │ コメント分析     │                            │
-│  │ 過去類似     │  │ + Tavily背景調査 │                            │
-│  │ スレッド検索 │  │ + LLM総合分析    │                            │
-│  └──────────────┘  └──────────────────┘                            │
-└────────────────────┬────────────────────────────────────────────────┘
-                     ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│ Reporter（reporter.py）                                             │
-│ ・調査結果をSlack Block Kit形式で通知                               │
-└─────────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+    subgraph Trigger["トリガー"]
+        Beat["Celery Beat（定期）"]
+        API["POST /hn-agent/run-all/<br/>POST /hn-agent/watcher/run/<br/>POST /hn-agent/investigate/"]
+    end
+
+    subgraph Watcher["Watcher（tasks.py）"]
+        Poll["poll_front_page<br/>・HN Algolia API で取得<br/>・HNThread / HNThreadSnapshot 更新<br/>・スコア / 速度閾値判定"]
+    end
+
+    subgraph Orch["Orchestrator（orchestrator.py）"]
+        ReAct["LangGraph ReAct Agent<br/>・system/user prompt を Langfuse 解決<br/>・detective_investigate を tool 呼び出し<br/>・最大 10 ステップで停止"]
+    end
+
+    subgraph Det["Detective（agents/detective.py）"]
+        Fetch["HN コメント取得（最大 50）<br/>+ Tavily Web 検索<br/>+ LLM で JSON 構造化分析"]
+    end
+
+    subgraph Report["Reporter（reporter.py）"]
+        Slack["Slack Block Kit で通知"]
+    end
+
+    Trigger --> Watcher
+    Watcher -->|閾値超えスレッド毎| Orch
+    Orch -->|tool call| Det
+    Det -->|結果| Orch
+    Orch --> Report
 ```
 
-## Orchestratorの判断フロー
+## 責務分離（LLM / Langfuse / 機能設定）
 
-OrchestratorはOpenAIの**Responses API**を利用し、LLM自身が「次にどのAgentを呼ぶべきか」を自律判断する。`reasoning`パラメータにより、LLMの判断理由もトレースに記録される。
+Orchestrator / Detective とも、LLM 接続とプロンプト管理が分離しています。
 
+```mermaid
+flowchart LR
+    subgraph Config["Django admin（DB）"]
+        HNAgentConfig["HNAgentConfig<br/>・score_threshold<br/>・front_page_limit<br/>・reasoning_effort<br/>・4 本の LangfusePromptRef FK"]
+        ServiceO["LLMServiceConfig<br/>service_name='orchestrator'"]
+        ServiceD["LLMServiceConfig<br/>service_name='detective'"]
+        Provider["LLMProviderConfig<br/>model_alias + Virtual Key"]
+        LPR["LangfusePromptRef<br/>(4 entries)"]
+    end
+
+    subgraph Code["ランタイム"]
+        Orchestrator
+        Detective
+    end
+
+    subgraph External["外部"]
+        LiteLLM[("LiteLLM Proxy")]
+        Langfuse[("Langfuse")]
+    end
+
+    HNAgentConfig -->|4 FKs| LPR
+    ServiceO --> Provider
+    ServiceD --> Provider
+
+    Orchestrator -->|get_llm_settings('orchestrator')| ServiceO
+    Detective -->|get_llm_settings('detective')| ServiceD
+    Orchestrator -->|resolve_prompt(ref, **vars)| LPR
+    Detective -->|resolve_prompt(ref, **vars)| LPR
+
+    Orchestrator -->|HTTPS| LiteLLM
+    Detective -->|HTTPS| LiteLLM
+    Orchestrator -.->|自動トレース| Langfuse
+    Detective -.->|自動トレース| Langfuse
+    LPR <-.->|get_prompt / compile| Langfuse
 ```
-[LLM] スレッド情報を受け取る
-  │
-  ├→ reasoning: 「過去に類似スレッドがないか確認すべき」
-  ├→ function_call: memory_search   → Memory Agentを実行 → 結果をLLMに返す
-  │
-  ├→ reasoning: 「急上昇の原因を調査する」
-  ├→ function_call: detective_investigate → Detective Agentを実行 → 結果をLLMに返す
-  │
-  └→ message（テキスト応答）        → 調査完了、最終サマリーを出力
-```
-
-最初の2ステップは`tool_choice="required"`で強制的にAgent呼び出しを行い、3ステップ目以降は`tool_choice="auto"`でLLMが結論を出せるようにしている。
 
 ## 各コンポーネント詳細
 
-### Watcher（tasks.py）
+### Watcher（`tasks.py`: `poll_front_page`）
 
-HNフロントページを定期ポーリングし、データを蓄積する。
+HN フロントページを定期ポーリングし、スナップショットを蓄積。
 
-- **入力**: なし（Celery Beatまたは手動トリガー）
-- **処理**:
-  1. HN Algolia APIでフロントページ上位30件を取得
-  2. `HNThread`にスレッド情報を保存（get_or_create）
-  3. `HNThreadSnapshot`にスコア・コメント数を時系列記録
-  4. 前回スナップショットとの差分からスコア上昇速度を計算
-  5. 閾値超えスレッドに対してOrchestratorをCeleryタスクとして起動
-- **出力**: 取得件数、新規スレッド数、トリガー数のサマリー
+- **入力**: なし（Celery Beat または `POST /hn-agent/watcher/run/` による手動トリガー）
+- **処理**
+  1. HN Algolia API で `HNAgentConfig.front_page_limit` 件を取得（デフォルト 30）
+  2. `HNThread` を `get_or_create`
+  3. `HNThreadSnapshot` にスコア・コメント数を時系列記録
+  4. 前回スナップショットとの差分から**スコア上昇速度**を計算
+  5. `score_threshold` または `velocity_threshold` を超えたスレッドを検出
+  6. `auto_investigate=True` の場合、Orchestrator を Celery タスクとして起動
+- **出力**: 取得件数、新規スレッド数、トリガー数
 
-### Memory Agent（agents/memory.py）
+### Orchestrator（`orchestrator.py`）
 
-pgvectorのcosine similarityで過去スレッドとの類似性を検索する。
+LangGraph の **ReAct Agent** を使い、LLM が「次のステップ」を自律判断。
 
-- **入力**: 調査対象`HNThread`
-- **処理**:
-  1. スレッドのタイトル+URLからOpenAI Embedding APIでベクトルを生成
-  2. `ThreadEmbedding`に保存（既存なら再利用）
-  3. pgvectorのCosineDistanceで全`ThreadEmbedding`と照合
-  4. 類似度閾値（デフォルト0.85）以上のスレッドを返す
-- **出力**: 類似スレッドのリスト（hn_id、タイトル、類似度）
-- **Investigationに保存**: agent_type="memory"
+- **入力**: 調査対象 `HNThread`
+- **処理**
+  1. `HNAgentConfig.objects.get_active_config()` で有効設定を取得
+  2. `LLMClient(service_name="orchestrator")` 相当の `ChatOpenAI` を構築
+  3. `resolve_prompt(config.orchestrator_system_prompt)` で system prompt 解決
+  4. `resolve_prompt(config.orchestrator_user_prompt, hn_id=..., title=..., …)` で user prompt 解決
+  5. `create_react_agent(llm, [detective_investigate])` で ReAct Agent を構築
+  6. エージェントが `detective_investigate` ツールを 1 回呼び、結論を出力
+  7. Reporter に結果を渡して Slack 通知
+- **特徴**
+  - `@observe(name="hn-agent/orchestrator", as_type="agent")` で Langfuse 上に agent span
+  - `_finalize_trace` で `decision_log`（実行ステップ一覧）をメタデータに記録
 
-### Detective Agent（agents/detective.py）
+### Detective Agent（`agents/detective.py`）
 
-スレッドが急上昇している理由を総合的に調査する。
+スレッド急上昇の原因を総合分析。
 
-- **入力**: 調査対象`HNThread`
-- **処理**:
-  1. HN Algolia APIでコメントを再帰取得（最大50件）
-  2. Tavily APIで投稿者・トピックの背景情報を検索
-  3. コメントテキスト + 背景情報をLLMに渡して分析
-  4. 「なぜ急上昇しているか」の構造化レポートを生成
-- **出力**: 分析テキスト、背景情報ソース、分析コメント数
-- **Investigationに保存**: agent_type="detective"
-- **副作用**: `HNThread.is_investigated = True`に更新
+- **入力**: 調査対象 `HNThread`
+- **処理**
+  1. HN Algolia API でコメントを再帰取得（最大 50 件）
+  2. Tavily API で投稿者・トピックの背景情報検索（設定なしの場合は skip）
+  3. `resolve_prompt(config.detective_system_prompt)` / `config.detective_user_prompt` で system/user prompt 解決
+  4. `LLMClient(service_name="detective").generate_text(...)` で分析
+  5. LLM の応答を JSON パース（`title_ja` / `why_trending` / `comment_highlights` など）
+- **出力**: 構造化分析結果（Slack 通知用）
+- **副作用**: `HNThread.is_investigated = True`
+- **特徴**
+  - `@observe(name="hn-agent/detective", as_type="tool")` で Orchestrator の子スパンとして記録
 
-### Reporter（reporter.py）
+### Reporter（`reporter.py`）
 
-調査結果をSlack Block Kit形式でフォーマットして通知する。
-
-- **対応フォーマット**:
-  - Detective Report: 分析結果 + コメントピックアップ + 参考情報リンク
-  - Memory Report: 類似スレッドリスト + 類似度
+調査結果を Slack Block Kit でフォーマットして通知。
 
 ## データモデル
 
 | モデル | 説明 |
-|--------|------|
-| `HNThread` | HNスレッドの基本情報（hn_id, title, url, author, is_investigated） |
-| `HNThreadSnapshot` | スコア・コメント数の時系列記録（上昇速度計算用） |
-| `ThreadEmbedding` | pgvectorによるembeddingベクトル（次元数は設定で可変） |
-| `Investigation` | エージェント調査結果（agent_type + JSON result） |
-| `HNAgentConfig` | エージェント動作パラメータ（閾値、次元数、ポーリング間隔） |
+|---|---|
+| `HNThread` | HN スレッドの基本情報（`hn_id`, `title`, `url`, `author`, `is_investigated`） |
+| `HNThreadSnapshot` | スコア・コメント数の時系列スナップショット（上昇速度の計算用） |
+| `HNAgentConfig` | エージェント動作パラメータ + 使用プロンプト 4 本（`LangfusePromptRef` FK） |
+
+※ `Memory Agent` / `ThreadEmbedding` / `Investigation` モデルは廃止されました（Langfuse トレースで代替）。
 
 ## 設定の管理
 
-全てDjango管理画面（`/admin/`）から設定する。
+Django 管理画面から（表示順は「AI ツール設定」グループ）:
 
 | 設定画面 | 管理内容 |
-|----------|---------|
-| **OpenAI API設定** | APIキー、チャットモデル、Embeddingモデル |
-| **Tavily API設定** | APIキー（Web検索用） |
-| **Slack通知設定** | Webhook URL |
-| **HN Agent設定** | 推論深度、Embedding次元数、スコア閾値、速度閾値、類似度閾値、ポーリング間隔 |
+|---|---|
+| **LLM 設定**（`LLMProviderConfig`） | モデルエイリアス + LiteLLM Virtual Key |
+| **LLM サービス設定**（`LLMServiceConfig`） | `orchestrator` / `detective` にプロバイダを割り当て |
+| **Langfuse プロンプト参照**（`LangfusePromptRef`） | `hn-agent-orchestrator-system/-user`, `hn-agent-detective-system/-user` の 4 本 |
+| **Slack 通知設定** | Webhook URL（暗号化保存） |
+| **Tavily** | API キー（Web 検索、任意） |
+| **HackerNews Agent 設定**（`HNAgentConfig`） | 推論深度、スコア閾値、速度閾値、ポーリング間隔、フロントページ取得件数、プロンプト 4 本 |
 
 ## API エンドポイント
 
 | メソッド | パス | 説明 |
-|---------|------|------|
-| `POST` | `/hn-agent/run-all/` | Watcher + Orchestrator一括実行 |
-| `POST` | `/hn-agent/watcher/run/` | Watcherのみ手動実行 |
-| `POST` | `/hn-agent/investigate/` | 指定hn_idのスレッドをOrchestrator調査 |
+|---|---|---|
+| `POST` | `/hn-agent/run-all/` | Watcher + Orchestrator 一括実行 |
+| `POST` | `/hn-agent/watcher/run/` | Watcher のみ手動実行 |
+| `POST` | `/hn-agent/investigate/` | 指定 `hn_id` を Orchestrator 調査 |
 | `GET` | `/hn-agent/threads/` | 監視中スレッド一覧 |
-| `GET` | `/hn-agent/investigations/` | 調査結果一覧 |
-| `GET` | `/hn-agent/investigations/<id>/` | 調査結果の詳細 |
 
 ## ファイル構成
 
 ```
 features/hn_agent/
-├── models.py          # HNThread, HNThreadSnapshot, ThreadEmbedding, Investigation, HNAgentConfig
-├── tasks.py           # Celeryタスク（poll_front_page, run_orchestrator, cleanup_old_snapshots）
-├── orchestrator.py    # Responses APIベースのOrchestrator
-├── tools.py           # OpenAI Responses API用ツール定義
-├── prompts.py         # Langfuseプロンプト取得ヘルパー
-├── reporter.py        # Slack通知フォーマッター
-├── views.py           # DRF APIビュー
-├── serializers.py     # DRFシリアライザ
-├── urls.py            # URLルーティング
-├── admin.py           # Django管理画面設定
+├── models.py                 # HNThread / HNThreadSnapshot / HNAgentConfig
+├── tasks.py                  # Celery タスク（poll_front_page, run_orchestrator, cleanup_old_snapshots）
+├── orchestrator.py           # LangGraph ReAct Agent ベースの Orchestrator
+├── reporter.py               # Slack Block Kit フォーマッター
+├── views.py                  # DRF API ビュー
+├── serializers.py            # DRF シリアライザ
+├── urls.py                   # URL ルーティング
+├── admin.py                  # Django 管理画面設定
 ├── agents/
-│   ├── memory.py      # Memory Agent（pgvector類似検索）
-│   └── detective.py   # Detective Agent（背景調査 + LLM分析）
+│   └── detective.py          # Detective Agent（背景調査 + LLM 分析）
 └── management/
     └── commands/
-        ├── run_hn_watcher.py       # Watcher手動実行
-        └── run_hn_investigation.py # Orchestrator手動実行
+        ├── run_hn_watcher.py       # Watcher 手動実行
+        └── run_hn_investigation.py # Orchestrator 手動実行
 ```
 
-## LLMOps（Langfuse統合）
+## LLMOps（Langfuse 統合）
 
-全LLM呼び出しはLangfuseでトレース・記録される。
+### プロンプト管理
 
-- **OpenAI drop-in wrapper**: `langfuse.openai.OpenAI`で全Generation/Embeddingを自動トレース
-- **@observe デコレータ**: APIエントリーポイント（`_run_all_impl`, `_investigate_impl`）とOrchestrator/Agentにスパン階層を構築
-- **Responses API + reasoning**: Orchestratorの判断理由をreasoningサマリーとして記録（対応モデルのみ）
-- **プロンプト管理**: `prompts.py`経由でLangfuse UIからプロンプトのバージョン管理・A/Bテストが可能
+| Langfuse プロンプト名 | 用途 |
+|---|---|
+| `hn-agent-orchestrator` | Orchestrator の system プロンプト |
+| `hn-agent-orchestrator-user` | Orchestrator の user プロンプト（`{{hn_id}}`, `{{title}}`, `{{url}}`, `{{author}}`, `{{score_info}}` を変数として使用） |
+| `hn-agent-detective` | Detective の system プロンプト（JSON スキーマ指定） |
+| `hn-agent-detective-user` | Detective の user プロンプト（`{{title}}`, `{{url}}`, `{{author}}`, `{{score_info}}`, `{{background_section}}`, `{{comments_section}}`） |
 
-環境変数:
-- `LANGFUSE_SECRET_KEY`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_BASE_URL`: Langfuse接続設定
-- `LANGFUSE_TRACING_ENVIRONMENT`: `dev`（開発）or `prd`（本番）
+Langfuse 未登録でも `LangfusePromptRef.fallback_text`（migration 0002 で投入済み）で動作します。
+
+### トレーシング
+
+- `langfuse.openai.OpenAI` drop-in wrapper により、全 LLM 呼び出しが自動でトレース・記録
+- `@observe` デコレータで API エントリーポイント / Orchestrator / Detective に span 階層を構築
+- Orchestrator の `_finalize_trace` で判断ログを `decision_log` としてメタデータ保存
+
+### 環境変数
+
+| 変数 | 説明 |
+|---|---|
+| `LANGFUSE_SECRET_KEY` / `LANGFUSE_PUBLIC_KEY` | Langfuse 認証 |
+| `LANGFUSE_BASE_URL` | self-hosted 使用時のみ |
+| `LANGFUSE_TRACING_ENVIRONMENT` | `dev` / `prd` |
 
 ## 依存する外部サービス
 
 | サービス | 用途 | 必須 |
-|---------|------|------|
-| OpenAI API | Responses API（Orchestrator）+ Chat Completions（分析）+ Embedding | 必須 |
+|---|---|---|
+| LiteLLM Proxy | LLM 呼び出しの共通入口（プロバイダー非依存） | 必須 |
 | HN Algolia API | スレッド・コメント取得 | 必須（無料） |
-| Tavily API | Web検索（背景調査） | 任意（未設定時はスキップ） |
-| Slack Webhook | 調査結果通知 | 任意（未設定時はスキップ） |
-| Langfuse | LLMトレーシング・プロンプト管理 | 任意（未設定時は無効） |
-| PostgreSQL + pgvector | Embedding保存・類似検索 | 必須 |
-| Redis | Celeryブローカー | 必須（定期実行時） |
+| PostgreSQL | スレッド・スナップショット保存 | 必須 |
+| Redis | Celery ブローカー | 必須（定期実行時） |
+| Tavily API | Web 検索（背景調査） | 任意（未設定時は skip） |
+| Slack Webhook | 調査結果通知 | 任意（未設定時は skip） |
+| Langfuse | LLM トレーシング・プロンプト管理 | 任意（未設定時は fallback_text で動作） |

--- a/django_api/features/hn_agent/README.md
+++ b/django_api/features/hn_agent/README.md
@@ -36,44 +36,30 @@ flowchart TB
     Orch --> Report
 ```
 
-## 責務分離（LLM / Langfuse / 機能設定）
+## admin 項目と外部サービスのつながり
 
-Orchestrator / Detective とも、LLM 接続とプロンプト管理が分離しています。
+HN Agent が使う admin 設定と、実際に叩く外部サービスの対応関係です。
 
 ```mermaid
 flowchart LR
-    subgraph Config["Django admin（DB）"]
-        HNAgentConfig["HNAgentConfig<br/>・score_threshold<br/>・front_page_limit<br/>・reasoning_effort<br/>・4 本の LangfusePromptRef FK"]
-        ServiceO["LLMServiceConfig<br/>service_name='orchestrator'"]
-        ServiceD["LLMServiceConfig<br/>service_name='detective'"]
-        Provider["LLMProviderConfig<br/>model_alias + Virtual Key"]
-        LPR["LangfusePromptRef<br/>(4 entries)"]
+    subgraph Admin["Django admin"]
+        HN["HackerNews Agent設定<br/>・閾値 / ポーリング / 取得件数<br/>・推論深度<br/>・4本のプロンプト参照FK"]
+        Service["LLMサービス設定<br/>orchestrator / detective"]
+        Provider["LLM設定<br/>model_alias + Virtual Key"]
+        Ref["Langfuseプロンプト参照<br/>hn-agent-* 4種"]
     end
 
-    subgraph Code["ランタイム"]
-        Orchestrator
-        Detective
+    subgraph External["外部サービス"]
+        LiteLLM[("LiteLLM Proxy<br/>/v1/chat/completions")]
+        Langfuse[("Langfuse<br/>get_prompt(name, label)")]
     end
 
-    subgraph External["外部"]
-        LiteLLM[("LiteLLM Proxy")]
-        Langfuse[("Langfuse")]
-    end
+    HN -->|4本| Ref
+    HN -.->|service_name で参照| Service
+    Service -->|provider_config| Provider
 
-    HNAgentConfig -->|4 FKs| LPR
-    ServiceO --> Provider
-    ServiceD --> Provider
-
-    Orchestrator -->|get_llm_settings('orchestrator')| ServiceO
-    Detective -->|get_llm_settings('detective')| ServiceD
-    Orchestrator -->|resolve_prompt(ref, **vars)| LPR
-    Detective -->|resolve_prompt(ref, **vars)| LPR
-
-    Orchestrator -->|HTTPS| LiteLLM
-    Detective -->|HTTPS| LiteLLM
-    Orchestrator -.->|自動トレース| Langfuse
-    Detective -.->|自動トレース| Langfuse
-    LPR <-.->|get_prompt / compile| Langfuse
+    Provider ==>|Virtual Key + model_alias| LiteLLM
+    Ref ==>|名前とラベルで取得| Langfuse
 ```
 
 ## 各コンポーネント詳細


### PR DESCRIPTION
## Summary

3 つの README を現行アーキテクチャに合わせて更新し、「admin 項目と LiteLLM/Langfuse のつながり」を 1 枚の Mermaid 図で示す。

## 含まれるコミット

- `30c8881` docs: README を全面改訂し LLM/LiteLLM/Langfuse の関係を Mermaid 図で明示
- `70264dd` docs: README の LLM/Langfuse 図をシンプル化

## 変更対象

- `README.md`
- `django_api/README.md`
- `django_api/features/hn_agent/README.md`

## Test plan

- [x] develop への PR (#210) 通過
- [ ] main への push で release.yml 通過