### PR TITLE
docs: Devil's Advocate / Security Responder 追加を各 README に反映

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ LLM 呼び出しは LiteLLM Proxy 経由でプロバイダー非依存、観測�
     - **features/** - ビジネス機能
         - 🎙️ **Talk**: 会話生成 API（プリセットベース・天気/予定/日時プレースホルダー対応・TTS 統合）
         - 📁 **Media**: メディア変換（画像フォーマット変換、ZIP → PDF）
-        - 🕵️ **HackerNews Agent**: HN 監視・分析エージェント（Watcher → Orchestrator → Detective → Slack 通知）
+        - 🕵️ **HackerNews Agent**: HN 監視・分析エージェント（Watcher → Orchestrator → Detective / Devil's Advocate / Security Responder → Slack 通知。LangGraph ReAct Agent がスレッド性質に応じて 3 ツールを使い分け）
 - 🎤 **Style-BERT-VITS2 API**: 日本語音声合成サービス（GPU）
 
 ## LLM / LiteLLM / Langfuse の関係
@@ -49,7 +49,7 @@ LLM 呼び出しは LiteLLM Proxy 経由でプロバイダー非依存、観測�
 - **Langfuse**（外部サービス / SaaS or self-hosted）
   LLM 呼び出しの観測（traces / generations / spans）と、バージョン管理付きのプロンプトテンプレート（`prompt.compile(**vars)`）を提供。
 - **`LLMProviderConfig`** / **`LLMServiceConfig`**（Django DB）
-  モデルエイリアス + Virtual Key をサービスごと（`orchestrator` / `detective` / `talk`）に割り当て。
+  モデルエイリアス + Virtual Key をサービスごと（`orchestrator` / `detective` / `devils_advocate` / `security_responder` / `talk`）に割り当て。
 - **`LangfusePromptRef`**（Django DB）
   Django 内識別名 ↔ Langfuse プロンプト名のマッピング + `fallback_text`。各機能（`HNAgentConfig` / `TalkConfig`）から FK で参照。
 - **`resolve_prompt(ref, **vars)`**（ユーティリティ）
@@ -61,7 +61,7 @@ LLM 呼び出しは LiteLLM Proxy 経由でプロバイダー非依存、観測�
 flowchart LR
     subgraph Admin["Django admin"]
         Provider["LLM設定<br/>model_alias + Virtual Key"]
-        Service["LLMサービス設定<br/>orchestrator / detective / talk"]
+        Service["LLMサービス設定<br/>orchestrator / detective /<br/>devils_advocate / security_responder / talk"]
         Ref["Langfuseプロンプト参照<br/>langfuse_prompt_name + label"]
         HN["HackerNews Agent設定"]
         Talk["Talk Generator"]
@@ -73,8 +73,8 @@ flowchart LR
     end
 
     Service -->|provider_config| Provider
-    HN -->|4本のプロンプト参照| Ref
-    HN -.->|orchestrator / detective| Service
+    HN -->|8本のプロンプト参照| Ref
+    HN -.->|orchestrator / detective /<br/>devils_advocate / security_responder| Service
     Talk -->|2本のプロンプト参照| Ref
     Talk -.->|talk| Service
 
@@ -94,6 +94,10 @@ flowchart LR
 | HN Agent Orchestrator user | `hn-agent-orchestrator-user` |
 | HN Agent Detective system | `hn-agent-detective` |
 | HN Agent Detective user | `hn-agent-detective-user` |
+| HN Agent Devil's Advocate system | `hn-agent-devils-advocate` |
+| HN Agent Devil's Advocate user | `hn-agent-devils-advocate-user` |
+| HN Agent Security Responder system | `hn-agent-security-responder` |
+| HN Agent Security Responder user | `hn-agent-security-responder-user` |
 | Talk system | `talk-{config_name}-system` |
 | Talk user | `talk-{config_name}-user` |
 

--- a/django_api/README.md
+++ b/django_api/README.md
@@ -13,7 +13,7 @@ REST API で複数の機能を提供するバックエンドサーバです。LL
 | tts | `/tts/` | テキスト読み上げ（Style-BERT-VITS2 プロキシ） |
 | weather | `/weather/` | 気象庁天気予報 |
 | talk | `/talk/` | 会話生成（Talk Generator） |
-| hn-agent | `/hn-agent/` | HackerNews Agent（監視・調査） |
+| hn-agent | `/hn-agent/` | HackerNews Agent（監視・調査・辛口分析・セキュリティ対応指針） |
 
 ## アーキテクチャの肝
 
@@ -24,9 +24,9 @@ LLM 周辺を 3 レイヤに分け、それぞれ Django admin で独立して�
 | レイヤ | モデル | 管理画面 | 役割 |
 |---|---|---|---|
 | LLM 接続 | `LLMProviderConfig` | 「LLM設定」 | モデルエイリアス + LiteLLM Virtual Key |
-| LLM 接続 | `LLMServiceConfig` | 「LLMサービス設定」 | `orchestrator` / `detective` / `talk` にプロバイダ割り当て + タイムアウト |
+| LLM 接続 | `LLMServiceConfig` | 「LLMサービス設定」 | `orchestrator` / `detective` / `devils_advocate` / `security_responder` / `talk` にプロバイダ割り当て + タイムアウト |
 | プロンプト管理 | `LangfusePromptRef` | 「Langfuseプロンプト参照」 | Langfuse プロンプト名 + ラベル + フォールバック |
-| 機能設定 | `HNAgentConfig` | 「HackerNews Agent設定」 | 閾値、ポーリング、取得件数、使用プロンプト 4 本 |
+| 機能設定 | `HNAgentConfig` | 「HackerNews Agent設定」 | 閾値、ポーリング、取得件数、使用プロンプト 8 本（Orchestrator / Detective / Devil's Advocate / Security Responder × system / user） |
 | 機能設定 | `TalkConfig` | 「Talk Generator」 | プリセットごとの動作パラメータ + 使用プロンプト 2 本 + TTS |
 
 **原則**: プロンプトとモデル接続が独立しているため、モデル差し替え（例: GPT-4o → Kimi K2.5）を行っても Langfuse 上のプロンプトは不変、プロンプト改修に Django 再デプロイは不要です。
@@ -37,7 +37,7 @@ LLM 周辺を 3 レイヤに分け、それぞれ Django admin で独立して�
 flowchart LR
     subgraph Admin["Django admin"]
         Provider["LLM設定<br/>model_alias + Virtual Key"]
-        Service["LLMサービス設定<br/>orchestrator / detective / talk"]
+        Service["LLMサービス設定<br/>orchestrator / detective /<br/>devils_advocate / security_responder / talk"]
         Ref["Langfuseプロンプト参照<br/>langfuse_prompt_name + label"]
         HN["HackerNews Agent設定"]
         Talk["Talk Generator"]
@@ -49,8 +49,8 @@ flowchart LR
     end
 
     Service -->|provider_config| Provider
-    HN -->|4本のプロンプト参照| Ref
-    HN -.->|orchestrator / detective| Service
+    HN -->|8本のプロンプト参照| Ref
+    HN -.->|orchestrator / detective /<br/>devils_advocate / security_responder| Service
     Talk -->|2本のプロンプト参照| Ref
     Talk -.->|talk| Service
 
@@ -164,14 +164,16 @@ Tavily Web 検索の API キー（暗号化保存）
 
 #### LLM サービス設定（`LLMServiceConfig`）
 
-各サービス（`orchestrator` / `detective` / `talk`）にどの `LLMProviderConfig` を使うかを割り当てます。
+各サービス（`orchestrator` / `detective` / `devils_advocate` / `security_responder` / `talk`）にどの `LLMProviderConfig` を使うかを割り当てます。
 
 | 項目 | 説明 |
 |---|---|
-| サービス名 | `HN Agent Orchestrator` / `HN Agent Detective` / `Talk Generator` |
+| サービス名 | `HN Agent Orchestrator` / `HN Agent Detective` / `HN Agent Devil's Advocate` / `HN Agent Security Responder` / `Talk Generator` |
 | LLM 設定 | 使用する `LLMProviderConfig` を選択 |
 | 有効 | サービス設定を有効化 |
 | タイムアウト（秒） | API リクエストタイムアウト（デフォルト 60） |
+
+> **Note:** `devils_advocate` / `security_responder` のサービス設定は migration 0012 で `detective` の設定を雛形として `is_active=False` で自動生成されます（detective が存在する場合）。プロバイダーを切り替えたい場合は管理画面で個別に編集してください。
 
 #### Langfuse プロンプト参照（`LangfusePromptRef`）
 
@@ -184,7 +186,7 @@ Langfuse 上のプロンプトを Django 側で参照するためのマッピン
 | ラベル | `production` / `staging`（Langfuse の version ラベル） |
 | フォールバックテキスト | Langfuse 不達時や未登録時に使用（`{{key}}` 変数は呼び出し側で置換） |
 
-初期データとして HN Agent 用 4 種（`hn-agent-orchestrator-system` / `-user`、`hn-agent-detective-system` / `-user`）が migration 0002 で自動投入されます。Talk 用は `TalkConfig` 作成時に自動生成されます。
+初期データとして HN Agent 用 8 種（`hn-agent-orchestrator-system` / `-user`、`hn-agent-detective-system` / `-user`、`hn-agent-devils-advocate-system` / `-user`、`hn-agent-security-responder-system` / `-user`）が migration 0002 + 0003 で自動投入されます。Talk 用は `TalkConfig` 作成時に自動生成されます。
 
 #### HackerNews Agent 設定（`HNAgentConfig`）
 
@@ -196,7 +198,7 @@ Langfuse 上のプロンプトを Django 側で参照するためのマッピン
 | 速度閾値 | 調査をトリガーするスコア上昇速度（ポイント/時間） |
 | ポーリング間隔（秒） | HN フロントページ取得の間隔（最低 60） |
 | フロントページ取得件数 | 1 回のポーリングで取得する件数（デフォルト 30、Algolia 経由で 90 以上も可） |
-| Orchestrator / Detective × system / user | 4 本の `LangfusePromptRef` FK |
+| Orchestrator / Detective / Devil's Advocate / Security Responder × system / user | 8 本の `LangfusePromptRef` FK |
 
 #### Talk Generator（`TalkConfig`）
 

--- a/django_api/features/hn_agent/README.md
+++ b/django_api/features/hn_agent/README.md
@@ -2,7 +2,15 @@
 
 ## 目的
 
-Hacker News のフロントページを定期監視し、急上昇するスレッドを検出して **AI が自律的に調査・分析**するエージェントシステム。「なぜ急上昇しているか」「コミュニティ内で意見が割れているか」を AI が判断して調査し、結果を Slack に通知します。
+Hacker News のフロントページを定期監視し、急上昇するスレッドを検出して **AI が自律的に調査・分析**するエージェントシステム。「なぜ急上昇しているか」「コミュニティ内で意見が割れているか」「新技術への辛口視点」「セキュリティインシデントの対応指針」を AI が判断して調査し、結果を Slack に通知します。
+
+Orchestrator は LangGraph ReAct Agent として動作し、スレッドの性質に応じて 3 種類の特化ツールを使い分けます。
+
+| ツール | 用途 | 典型的な呼び出しパターン |
+|---|---|---|
+| `detective_investigate` | 汎用調査（タイトル和訳、注目理由、背景、コメント要約） | 一般ニュース → 単独 |
+| `devils_advocate_analyze` | 新技術・Show HN・アーキテクチャ議論への辛口視点（懸念点・過去事例・批判コメント） | 新技術発表 → `detective` と併用 |
+| `security_responder_analyze` | 脆弱性・CVE・インシデント対応指針（影響範囲・回避策・公式パッチ） | セキュリティ話題 → 単独 |
 
 ## 全体アーキテクチャ
 
@@ -18,21 +26,27 @@ flowchart TB
     end
 
     subgraph Orch["Orchestrator（orchestrator.py）"]
-        ReAct["LangGraph ReAct Agent<br/>・system/user prompt を Langfuse 解決<br/>・detective_investigate を tool 呼び出し<br/>・最大 10 ステップで停止"]
+        ReAct["LangGraph ReAct Agent<br/>・system/user prompt を Langfuse 解決<br/>・3 ツールから発火条件に応じて選択<br/>・最大 10 ステップで停止<br/>・is_investigated 一元管理"]
     end
 
-    subgraph Det["Detective（agents/detective.py）"]
-        Fetch["HN コメント取得（最大 50）<br/>+ Tavily Web 検索<br/>+ LLM で JSON 構造化分析"]
+    subgraph Tools["サブエージェント（agents/*.py）"]
+        Det["Detective<br/>汎用調査 + Tavily 背景検索"]
+        Devil["Devil's Advocate<br/>辛口・批判的視点抽出"]
+        Sec["Security Responder<br/>CVE / 影響範囲 / パッチ整理<br/>（Tavily でセキュリティ情報補強）"]
     end
 
     subgraph Report["Reporter（reporter.py）"]
-        Slack["Slack Block Kit で通知"]
+        Slack["Slack Block Kit で通知<br/>・🔍 Detective レポート<br/>・🛑 辛口な意見<br/>・🚨 セキュリティ詳細"]
     end
 
     Trigger --> Watcher
     Watcher -->|閾値超えスレッド毎| Orch
     Orch -->|tool call| Det
+    Orch -->|tool call| Devil
+    Orch -->|tool call| Sec
     Det -->|結果| Orch
+    Devil -->|結果| Orch
+    Sec -->|結果| Orch
     Orch --> Report
 ```
 
@@ -43,10 +57,10 @@ HN Agent が使う admin 設定と、実際に叩く外部サービスの対応�
 ```mermaid
 flowchart LR
     subgraph Admin["Django admin"]
-        HN["HackerNews Agent設定<br/>・閾値 / ポーリング / 取得件数<br/>・推論深度<br/>・4本のプロンプト参照FK"]
-        Service["LLMサービス設定<br/>orchestrator / detective"]
+        HN["HackerNews Agent設定<br/>・閾値 / ポーリング / 取得件数<br/>・推論深度<br/>・8本のプロンプト参照FK"]
+        Service["LLMサービス設定<br/>orchestrator / detective /<br/>devils_advocate / security_responder"]
         Provider["LLM設定<br/>model_alias + Virtual Key"]
-        Ref["Langfuseプロンプト参照<br/>hn-agent-* 4種"]
+        Ref["Langfuseプロンプト参照<br/>hn-agent-* 8種"]
     end
 
     subgraph External["外部サービス"]
@@ -54,7 +68,7 @@ flowchart LR
         Langfuse[("Langfuse<br/>get_prompt(name, label)")]
     end
 
-    HN -->|4本| Ref
+    HN -->|8本| Ref
     HN -.->|service_name で参照| Service
     Service -->|provider_config| Provider
 
@@ -80,24 +94,30 @@ HN フロントページを定期ポーリングし、スナップショット�
 
 ### Orchestrator（`orchestrator.py`）
 
-LangGraph の **ReAct Agent** を使い、LLM が「次のステップ」を自律判断。
+LangGraph の **ReAct Agent** を使い、LLM が「どのツールをどの順で呼ぶか」を自律判断。
 
 - **入力**: 調査対象 `HNThread`
 - **処理**
-  1. `HNAgentConfig.objects.get_active_config()` で有効設定を取得
+  1. `HNAgentConfig.objects.get_active_config()` で有効設定を取得（8 FK を先読み）
   2. `LLMClient(service_name="orchestrator")` 相当の `ChatOpenAI` を構築
   3. `resolve_prompt(config.orchestrator_system_prompt)` で system prompt 解決
   4. `resolve_prompt(config.orchestrator_user_prompt, hn_id=..., title=..., …)` で user prompt 解決
-  5. `create_react_agent(llm, [detective_investigate])` で ReAct Agent を構築
-  6. エージェントが `detective_investigate` ツールを 1 回呼び、結論を出力
-  7. Reporter に結果を渡して Slack 通知
+  5. `create_react_agent(llm, [detective_investigate, devils_advocate_analyze, security_responder_analyze])` で 3 ツール対応の ReAct Agent を構築
+  6. 各ツールの docstring（発火条件を含む）を見て LLM がどのツールを何回呼ぶかを判断
+  7. いずれかのエージェントが結果を返した場合のみ `HNThread.is_investigated = True` を一元的に更新
+  8. Reporter に結果を渡して Slack 通知
+- **ツール選択の判断基準（System Prompt）**
+  1. セキュリティ話題（脆弱性/CVE/情報漏洩/ハッキング/0-day） → `security_responder_analyze` 単独
+  2. 新技術・プロダクト発表（Show HN/アーキテクチャ論争） → `detective_investigate` + `devils_advocate_analyze`
+  3. それ以外（一般ニュース・話題性） → `detective_investigate` 単独
 - **特徴**
   - `@observe(name="hn-agent/orchestrator", as_type="agent")` で Langfuse 上に agent span
   - `_finalize_trace` で `decision_log`（実行ステップ一覧）をメタデータに記録
+  - セキュリティ単独呼び出しでも無限ループしないよう、`is_investigated` の責務を Orchestrator に一元化
 
 ### Detective Agent（`agents/detective.py`）
 
-スレッド急上昇の原因を総合分析。
+スレッド急上昇の原因を汎用的に総合分析。
 
 - **入力**: 調査対象 `HNThread`
 - **処理**
@@ -107,13 +127,57 @@ LangGraph の **ReAct Agent** を使い、LLM が「次のステップ」を自�
   4. `LLMClient(service_name="detective").generate_text(...)` で分析
   5. LLM の応答を JSON パース（`title_ja` / `why_trending` / `comment_highlights` など）
 - **出力**: 構造化分析結果（Slack 通知用）
-- **副作用**: `HNThread.is_investigated = True`
 - **特徴**
   - `@observe(name="hn-agent/detective", as_type="tool")` で Orchestrator の子スパンとして記録
 
+### Devil's Advocate Agent（`agents/devils_advocate.py`）
+
+新技術・Show HN・アーキテクチャ議論などに対して、HN 民の辛口・批判的視点を抽出。
+
+- **入力**: 調査対象 `HNThread`
+- **処理**
+  1. HN コメントを取得（最大 50 件、Tavily は使わない）
+  2. `resolve_prompt(config.devils_advocate_system_prompt)` / `config.devils_advocate_user_prompt` で prompt 解決
+  3. `LLMClient(service_name="devils_advocate").generate_text(...)` で分析
+  4. LLM の応答を JSON パース
+- **出力**: 構造化分析結果
+  - `concerns[]`: 懸念点・トレードオフ
+  - `past_cases[]`: 過去の類似技術 + 教訓
+  - `critical_comments[]`: 批判的コメント（著者・意訳・観点カテゴリ）
+  - `summary`: 辛口視点での総括
+- **特徴**
+  - `@observe(name="hn-agent/devils-advocate", as_type="tool")` で Orchestrator の子スパン
+
+### Security Responder Agent（`agents/security_responder.py`）
+
+脆弱性・CVE・情報漏洩・ハッキングなどのスレッドで、エンジニアの対応方針を明確化。
+
+- **入力**: 調査対象 `HNThread`
+- **処理**
+  1. HN コメントを取得
+  2. Tavily API で CVE / advisory / patch / workaround を検索（クエリ例: `f"{title} CVE advisory patch workaround"`、設定なしの場合は skip）
+  3. `resolve_prompt(config.security_responder_system_prompt)` / `config.security_responder_user_prompt` で prompt 解決
+  4. `LLMClient(service_name="security_responder").generate_text(...)` で分析
+  5. LLM の応答を JSON パース
+- **出力**: 構造化分析結果
+  - `cve_ids[]`: CVE ID（無ければ `[]`）
+  - `affected[]`: 影響を受ける製品・バージョン
+  - `workarounds[]`: パッチが適用できない場合の回避策
+  - `official_patch`: `{available, version, url}` 形式のパッチ情報
+  - `severity`: `critical` / `high` / `medium` / `low` / `unknown`
+  - `summary`: 対応指針サマリ
+- **特徴**
+  - `@observe(name="hn-agent/security-responder", as_type="tool")` で Orchestrator の子スパン
+
 ### Reporter（`reporter.py`）
 
-調査結果を Slack Block Kit でフォーマットして通知。
+調査結果を Slack Block Kit でフォーマットして通知。エージェントごとに専用のブロック構造を持つ。
+
+- `report_detective(result)`: 🔍 汎用調査レポート（タイトル和訳・注目理由・コメントピックアップ）
+- `report_devils_advocate(result)`: 🛑 HN 民の辛口な意見（懸念点・過去事例・批判コメント）
+- `report_security_responder(result)`: 🚨 セキュリティインシデント詳細（severity を色付き emoji で表示、CVE・影響範囲・回避策・公式パッチ）
+
+**URL サニタイズ**: LLM が生成した `official_patch.url` や Tavily 検索結果の URL は、`_sanitize_url` によって `javascript:` 等の危険スキームと `|`/`<`/`>`/改行の mrkdwn 構造破壊文字を拒否してから Slack に送信します。
 
 ## データモデル
 
@@ -121,7 +185,7 @@ LangGraph の **ReAct Agent** を使い、LLM が「次のステップ」を自�
 |---|---|
 | `HNThread` | HN スレッドの基本情報（`hn_id`, `title`, `url`, `author`, `is_investigated`） |
 | `HNThreadSnapshot` | スコア・コメント数の時系列スナップショット（上昇速度の計算用） |
-| `HNAgentConfig` | エージェント動作パラメータ + 使用プロンプト 4 本（`LangfusePromptRef` FK） |
+| `HNAgentConfig` | エージェント動作パラメータ + 使用プロンプト 8 本（`LangfusePromptRef` FK：Orchestrator / Detective / Devil's Advocate / Security Responder それぞれ system / user） |
 
 ※ `Memory Agent` / `ThreadEmbedding` / `Investigation` モデルは廃止されました（Langfuse トレースで代替）。
 
@@ -132,11 +196,13 @@ Django 管理画面から（表示順は「AI ツール設定」グループ）:
 | 設定画面 | 管理内容 |
 |---|---|
 | **LLM 設定**（`LLMProviderConfig`） | モデルエイリアス + LiteLLM Virtual Key |
-| **LLM サービス設定**（`LLMServiceConfig`） | `orchestrator` / `detective` にプロバイダを割り当て |
-| **Langfuse プロンプト参照**（`LangfusePromptRef`） | `hn-agent-orchestrator-system/-user`, `hn-agent-detective-system/-user` の 4 本 |
+| **LLM サービス設定**（`LLMServiceConfig`） | `orchestrator` / `detective` / `devils_advocate` / `security_responder` の 4 サービスにプロバイダを割り当て |
+| **Langfuse プロンプト参照**（`LangfusePromptRef`） | `hn-agent-orchestrator-system/-user`, `hn-agent-detective-system/-user`, `hn-agent-devils-advocate-system/-user`, `hn-agent-security-responder-system/-user` の 8 本 |
 | **Slack 通知設定** | Webhook URL（暗号化保存） |
-| **Tavily** | API キー（Web 検索、任意） |
-| **HackerNews Agent 設定**（`HNAgentConfig`） | 推論深度、スコア閾値、速度閾値、ポーリング間隔、フロントページ取得件数、プロンプト 4 本 |
+| **Tavily** | API キー（Web 検索、Detective・Security Responder で使用、任意） |
+| **HackerNews Agent 設定**（`HNAgentConfig`） | 推論深度、スコア閾値、速度閾値、ポーリング間隔、フロントページ取得件数、プロンプト 8 本 |
+
+> **Note:** `devils_advocate` / `security_responder` の `LLMServiceConfig` は、`detective` の設定が存在する状態で migration 0012 を適用すると、同じ `LLMProviderConfig` を共有する形で **`is_active=False` の雛形**として自動生成されます。管理画面から個別のプロバイダーへ切り替え可能です。
 
 ## API エンドポイント
 
@@ -160,7 +226,9 @@ features/hn_agent/
 ├── urls.py                   # URL ルーティング
 ├── admin.py                  # Django 管理画面設定
 ├── agents/
-│   └── detective.py          # Detective Agent（背景調査 + LLM 分析）
+│   ├── detective.py          # Detective Agent（汎用調査 + Tavily 背景検索）
+│   ├── devils_advocate.py    # Devil's Advocate Agent（辛口・批判的視点抽出）
+│   └── security_responder.py # Security Responder Agent（CVE / パッチ整理）
 └── management/
     └── commands/
         ├── run_hn_watcher.py       # Watcher 手動実行
@@ -173,12 +241,19 @@ features/hn_agent/
 
 | Langfuse プロンプト名 | 用途 |
 |---|---|
-| `hn-agent-orchestrator` | Orchestrator の system プロンプト |
-| `hn-agent-orchestrator-user` | Orchestrator の user プロンプト（`{{hn_id}}`, `{{title}}`, `{{url}}`, `{{author}}`, `{{score_info}}` を変数として使用） |
+| `hn-agent-orchestrator` | Orchestrator の system プロンプト（3 ツールの発火条件を明記） |
+| `hn-agent-orchestrator-user` | Orchestrator の user プロンプト（`{{hn_id}}`, `{{title}}`, `{{url}}`, `{{author}}`, `{{score_info}}`） |
 | `hn-agent-detective` | Detective の system プロンプト（JSON スキーマ指定） |
 | `hn-agent-detective-user` | Detective の user プロンプト（`{{title}}`, `{{url}}`, `{{author}}`, `{{score_info}}`, `{{background_section}}`, `{{comments_section}}`） |
+| `hn-agent-devils-advocate` | Devil's Advocate の system プロンプト（concerns / past_cases / critical_comments / summary の JSON スキーマ指定） |
+| `hn-agent-devils-advocate-user` | Devil's Advocate の user プロンプト（`{{title}}`, `{{url}}`, `{{author}}`, `{{score_info}}`, `{{comments_section}}`） |
+| `hn-agent-security-responder` | Security Responder の system プロンプト（cve_ids / affected / workarounds / official_patch / severity / summary の JSON スキーマ指定） |
+| `hn-agent-security-responder-user` | Security Responder の user プロンプト（`{{title}}`, `{{url}}`, `{{author}}`, `{{score_info}}`, `{{comments_section}}`, `{{search_section}}`） |
 
-Langfuse 未登録でも `LangfusePromptRef.fallback_text`（migration 0002 で投入済み）で動作します。
+Langfuse 未登録でも `LangfusePromptRef.fallback_text` で動作します。初期データは以下 2 本の migration で自動投入されます:
+
+- `integrations/langfuse/migrations/0002_seed_default_refs.py`: Orchestrator / Detective 用 4 種
+- `integrations/langfuse/migrations/0003_seed_new_agent_refs.py`: Devil's Advocate / Security Responder 用 4 種、および Orchestrator の fallback_text を 3 ツール判断基準付きに更新
 
 ### トレーシング
 


### PR DESCRIPTION
## Summary

PR #212 で追加した Devil's Advocate / Security Responder のサブエージェント構成を、3 つの README に反映しました。

## 更新ファイル

- \`README.md\`（リポジトリトップ）
- \`django_api/README.md\`
- \`django_api/features/hn_agent/README.md\`

## 主な変更点

### hn_agent/README.md
- 3 ツールの発火条件表を新設（detective / devils_advocate / security_responder）
- 全体アーキテクチャの Mermaid 図を 3 サブエージェント + Slack 3 種通知に更新
- \`admin 項目と外部サービスのつながり\` の LLMサービス設定と プロンプト参照（4→8本）を更新
- Devil's Advocate Agent / Security Responder Agent の詳細セクションを新規追加（出力 JSON スキーマ、Tavily 利用有無、@observe 名）
- Orchestrator の判断基準（セキュリティ単独 / 新技術は併用 / それ以外は detective 単独）を追記
- Orchestrator で \`is_investigated\` を一元管理する旨を明記
- Reporter に URL サニタイズ（\`javascript:\` 拒否、mrkdwn 構造破壊文字拒否）の記述追加
- 初期データ投入マイグレーション（0002 + 0003）の責任分担を記載

### django_api/README.md
- LLMサービス設定の choices を 3 → 5 に更新
- HNAgentConfig のプロンプト参照を 4 → 8 本に
- 0012 migration で detective 設定を雛形に新エージェント用 LLMServiceConfig が \`is_active=False\` で自動生成される旨を追記

### README.md
- サービス一覧の HN Agent 説明を 3 サブエージェント構成に更新
- LLM/Langfuse 図の LLMサービス・プロンプト参照件数を 3→5、4本→8本に
- Langfuse プロンプト命名規約表に 4 エントリ（Devil's Advocate / Security Responder の system / user）を追加

## Test plan

- [x] Markdown の lint 相当: Ruff 対象外、見た目は CLI で確認
- [ ] PR Checks（docs のみの変更なので pr-checks.yml は最小構成で通過見込み）