### PR TITLE
feat: 会話生成画面にカスタムユーザープロンプト入力を追加

### DIFF
--- a/frontend/src/features/talk/GenerateForm.tsx
+++ b/frontend/src/features/talk/GenerateForm.tsx
@@ -8,12 +8,15 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
-import type { GenerateConfig } from '@/types/talk';
+import { Textarea } from '@/components/ui/textarea';
+import { USER_PROMPT_MAX_LENGTH, type GenerateConfig } from '@/types/talk';
 
 interface GenerateFormProps {
     readonly configs: GenerateConfig[];
     readonly selectedConfig: string;
     readonly onConfigChange: (config: string) => void;
+    readonly userPrompt: string;
+    readonly onUserPromptChange: (value: string) => void;
     readonly onSubmit: () => void;
     readonly isLoading: boolean;
 }
@@ -22,17 +25,21 @@ export function GenerateForm({
     configs,
     selectedConfig,
     onConfigChange,
+    userPrompt,
+    onUserPromptChange,
     onSubmit,
     isLoading,
 }: GenerateFormProps) {
+    const selected = configs.find((c) => c.name === selectedConfig);
+    const promptLength = userPrompt.length;
+    const isOverLimit = promptLength > USER_PROMPT_MAX_LENGTH;
+
     const handleSubmit = (e: FormEvent) => {
         e.preventDefault();
-        if (selectedConfig && !isLoading) {
+        if (selectedConfig && !isLoading && !isOverLimit) {
             onSubmit();
         }
     };
-
-    const selected = configs.find((c) => c.name === selectedConfig);
 
     return (
         <form onSubmit={handleSubmit} className="space-y-3.5">
@@ -55,35 +62,53 @@ export function GenerateForm({
                         ))}
                     </SelectContent>
                 </Select>
-                {selected && (
+                {selected?.tts_enabled && (
                     <div className="flex flex-wrap gap-2 text-xs">
-                        {selected.use_datetime && (
-                            <span className="rounded-md border border-[oklch(0.75_0.20_155/0.2)] bg-[oklch(0.75_0.20_155/0.08)] px-1.5 py-0.5 text-[oklch(0.75_0.20_155)]">
-                                日時
-                            </span>
-                        )}
-                        {selected.use_weather && (
-                            <span className="rounded-md border border-[oklch(0.75_0.20_155/0.2)] bg-[oklch(0.75_0.20_155/0.08)] px-1.5 py-0.5 text-[oklch(0.75_0.20_155)]">
-                                天気
-                            </span>
-                        )}
-                        {selected.use_events && (
-                            <span className="rounded-md border border-[oklch(0.75_0.20_155/0.2)] bg-[oklch(0.75_0.20_155/0.08)] px-1.5 py-0.5 text-[oklch(0.75_0.20_155)]">
-                                予定
-                            </span>
-                        )}
-                        {selected.tts_enabled && (
-                            <span className="rounded-md border border-[oklch(0.72_0.20_155/0.2)] bg-[oklch(0.72_0.20_155/0.1)] px-1.5 py-0.5 text-[oklch(0.72_0.20_155)]">
-                                TTS有効
-                            </span>
-                        )}
+                        <span className="rounded-md border border-[oklch(0.72_0.20_155/0.2)] bg-[oklch(0.72_0.20_155/0.1)] px-1.5 py-0.5 text-[oklch(0.72_0.20_155)]">
+                            TTS有効
+                        </span>
                     </div>
                 )}
             </div>
 
+            <div className="space-y-2">
+                <Label
+                    htmlFor="user-prompt"
+                    className="text-[13px] font-medium"
+                >
+                    カスタムユーザープロンプト（任意）
+                </Label>
+                <Textarea
+                    id="user-prompt"
+                    value={userPrompt}
+                    onChange={(e) => onUserPromptChange(e.target.value)}
+                    placeholder="例: 今日は {{datetime}} です。一言お願いします。"
+                    rows={4}
+                    aria-invalid={isOverLimit || undefined}
+                    aria-describedby="user-prompt-help"
+                />
+                <div
+                    id="user-prompt-help"
+                    className="text-muted-foreground flex items-center justify-between text-[12px] leading-relaxed"
+                >
+                    <span>
+                        利用可能: <code>{'{{datetime}}'}</code>{' '}
+                        <code>{'{{weather}}'}</code> <code>{'{{events}}'}</code>
+                    </span>
+                    <span
+                        className={
+                            isOverLimit
+                                ? 'text-destructive font-medium'
+                                : undefined
+                        }
+                    >
+                        {promptLength} / {USER_PROMPT_MAX_LENGTH}
+                    </span>
+                </div>
+            </div>
+
             <p className="text-muted-foreground text-[12px] leading-relaxed">
-                プロンプトはサーバー側（Langfuse）で管理されています。
-                プリセットを選んで生成ボタンを押してください。
+                未入力ならサーバー側（Langfuse）のプロンプトを使用します。
             </p>
 
             <LoadingButton
@@ -91,7 +116,7 @@ export function GenerateForm({
                 className="mt-1 w-full font-medium"
                 isLoading={isLoading}
                 loadingText="生成中..."
-                disabled={!selectedConfig}
+                disabled={!selectedConfig || isOverLimit}
             >
                 テキストを生成
             </LoadingButton>

--- a/frontend/src/features/talk/GeneratePage.tsx
+++ b/frontend/src/features/talk/GeneratePage.tsx
@@ -18,6 +18,8 @@ export function GeneratePage() {
         configs,
         selectedConfig,
         setSelectedConfig,
+        userPrompt,
+        setUserPrompt,
         result,
         isLoading,
         error,
@@ -47,6 +49,8 @@ export function GeneratePage() {
                         configs={configs}
                         selectedConfig={selectedConfig}
                         onConfigChange={setSelectedConfig}
+                        userPrompt={userPrompt}
+                        onUserPromptChange={setUserPrompt}
                         onSubmit={handleGenerate}
                         isLoading={isLoading}
                     />

--- a/frontend/src/features/talk/useGenerate.ts
+++ b/frontend/src/features/talk/useGenerate.ts
@@ -1,11 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { fetchConfigs, generateText } from '@/lib/api/talk';
-import type { GenerateConfig, GenerateResult } from '@/types/talk';
+import type {
+    GenerateConfig,
+    GenerateRequest,
+    GenerateResult,
+} from '@/types/talk';
 
 export function useGenerate() {
     const [configs, setConfigs] = useState<GenerateConfig[]>([]);
     const [selectedConfig, setSelectedConfig] = useState<string>('');
+    const [userPrompt, setUserPrompt] = useState<string>('');
     const [result, setResult] = useState<GenerateResult | null>(null);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -33,9 +38,15 @@ export function useGenerate() {
         }
 
         try {
-            const generateResult = await generateText({
-                config_name: selectedConfig,
-            });
+            const trimmed = userPrompt.trim();
+            const request: GenerateRequest =
+                trimmed === ''
+                    ? { config_name: selectedConfig }
+                    : {
+                          config_name: selectedConfig,
+                          user_prompt: userPrompt,
+                      };
+            const generateResult = await generateText(request);
             if (generateResult.audioUrl) {
                 previousUrlRef.current = generateResult.audioUrl;
             }
@@ -47,7 +58,7 @@ export function useGenerate() {
         } finally {
             setIsLoading(false);
         }
-    }, [selectedConfig]);
+    }, [selectedConfig, userPrompt]);
 
     useEffect(() => {
         return () => {
@@ -61,6 +72,8 @@ export function useGenerate() {
         configs,
         selectedConfig,
         setSelectedConfig,
+        userPrompt,
+        setUserPrompt,
         result,
         isLoading,
         error,

--- a/frontend/src/types/talk.ts
+++ b/frontend/src/types/talk.ts
@@ -2,13 +2,11 @@ export interface GenerateConfig {
     readonly name: string;
     readonly display_name: string;
     readonly tts_enabled: boolean;
-    readonly use_weather: boolean;
-    readonly use_events: boolean;
-    readonly use_datetime: boolean;
 }
 
 export interface GenerateRequest {
     readonly config_name: string;
+    readonly user_prompt?: string;
 }
 
 export interface GenerateResult {
@@ -16,3 +14,5 @@ export interface GenerateResult {
     readonly audioBlob: Blob | null;
     readonly audioUrl: string | null;
 }
+
+export const USER_PROMPT_MAX_LENGTH = 4000;

--- a/frontend/tests/lib/api/talk.test.ts
+++ b/frontend/tests/lib/api/talk.test.ts
@@ -10,6 +10,8 @@ import {
 } from 'vitest';
 import { fetchConfigs, generateText } from '@/lib/api/talk';
 
+let lastSynthesizeBody: Record<string, unknown> | null = null;
+
 const server = setupServer(
     http.get('*/api/talk/configs/', () => {
         return HttpResponse.json({
@@ -18,14 +20,12 @@ const server = setupServer(
                     name: 'morning',
                     display_name: '朝のあいさつ',
                     tts_enabled: true,
-                    use_weather: true,
-                    use_events: true,
-                    use_datetime: true,
                 },
             ],
         });
     }),
-    http.post('*/api/talk/synthesize/', () => {
+    http.post('*/api/talk/synthesize/', async ({ request }) => {
+        lastSynthesizeBody = (await request.json()) as Record<string, unknown>;
         // Base64エンコードされたfake audio data
         const audioData = btoa('fake-audio-data');
         return HttpResponse.json({
@@ -37,7 +37,10 @@ const server = setupServer(
 );
 
 beforeAll(() => server.listen());
-afterEach(() => server.resetHandlers());
+afterEach(() => {
+    server.resetHandlers();
+    lastSynthesizeBody = null;
+});
 afterAll(() => server.close());
 
 describe('Generate API', () => {
@@ -55,5 +58,21 @@ describe('Generate API', () => {
         expect(result.text).toBe('おはようございます');
         expect(result.audioBlob).toBeInstanceOf(Blob);
         expect(result.audioBlob!.size).toBe('fake-audio-data'.length);
+    });
+
+    it('user_prompt 未指定時はリクエストに含まれない', async () => {
+        await generateText({ config_name: 'morning' });
+        expect(lastSynthesizeBody).toEqual({ config_name: 'morning' });
+    });
+
+    it('user_prompt 指定時はリクエストに含まれる', async () => {
+        await generateText({
+            config_name: 'morning',
+            user_prompt: '今日は {{datetime}} です',
+        });
+        expect(lastSynthesizeBody).toEqual({
+            config_name: 'morning',
+            user_prompt: '今日は {{datetime}} です',
+        });
     });
 });


### PR DESCRIPTION
## Summary

- フロントエンドの `/talk` 画面に **カスタムユーザープロンプト** 入力欄（Textarea）を追加
- バックエンド側 #216 の `user_prompt` 対応に合わせた UI 実装
- `GenerateConfig` 型から削除済の `use_weather` / `use_events` / `use_datetime` を除去

## UI 仕様

- ラベル: 「カスタムユーザープロンプト（任意）」
- プレースホルダー例: `今日は {{datetime}} です。一言お願いします。`
- 補助: `利用可能: {{datetime}} {{weather}} {{events}}`
- 文字数カウンタ表示、最大 4000 文字（バックエンドと整合）
- 超過時: aria-invalid + ボタン disable
- 未入力時: 既存動作（Langfuse プロンプトを使用）

## コード変更

- `frontend/src/types/talk.ts`: `GenerateRequest.user_prompt?: string` 追加、`GenerateConfig.use_*` 削除、`USER_PROMPT_MAX_LENGTH = 4000` 定数追加
- `frontend/src/features/talk/useGenerate.ts`: `userPrompt` state 追加、trim 後非空ならリクエストに含める
- `frontend/src/features/talk/GenerateForm.tsx`: Textarea + カウンタ追加、`use_*` バッジ削除（TTS 有効バッジは保持）
- `frontend/src/features/talk/GeneratePage.tsx`: props 伝達
- `frontend/tests/lib/api/talk.test.ts`: MSW モック更新 + user_prompt 送信テスト 2 件追加

## 検証結果

- Vitest: 29 テスト全パス
- ESLint: エラーなし（既存 coverage ディレクトリ警告のみ）
- Prettier: フォーマット済
- `pnpm build`: 成功（TypeScript コンパイル + Vite ビルド）

## Test plan

- [ ] CI（pr-checks.yml）の frontend-test が緑
- [ ] マージ後 build.yml で frontend イメージが GHCR にプッシュされる
- [ ] デプロイ後、`/talk` 画面でカスタムプロンプト入力 → 送信 → LLM 応答が返ることを確認
- [ ] 4001 文字入力時にボタンが disable になることを確認