### PR TITLE
release: README 更新（チャット履歴永続化機能の文書化, PR #222 統合）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # 鍵山製パン社内 Web アプリケーション
 
+> **Docker × Django REST × React SPA で構築する社内ツール基盤。**
+> LiteLLM Proxy + Langfuse で LLMOps を一元化し、ChatGPT 風の **チャット履歴付き音声会話**、テキスト読み上げ、OneDrive / Outlook 連携、HackerNews 監視エージェントなどを統合。
+
+[![Python](https://img.shields.io/badge/Python_3.13-3776AB?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/)
+[![Django](https://img.shields.io/badge/Django_6-092E20?style=for-the-badge&logo=django&logoColor=white)](https://www.djangoproject.com/)
+[![React](https://img.shields.io/badge/React_19-61DAFB?style=for-the-badge&logo=react&logoColor=black)](https://react.dev/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Vite](https://img.shields.io/badge/Vite-646CFF?style=for-the-badge&logo=vite&logoColor=white)](https://vitejs.dev/)
+[![Tailwind CSS](https://img.shields.io/badge/Tailwind_v4-06B6D4?style=for-the-badge&logo=tailwindcss&logoColor=white)](https://tailwindcss.com/)
+[![PostgreSQL](https://img.shields.io/badge/PostgreSQL_17-4169E1?style=for-the-badge&logo=postgresql&logoColor=white)](https://www.postgresql.org/)
+[![pnpm](https://img.shields.io/badge/pnpm-F69220?style=for-the-badge&logo=pnpm&logoColor=white)](https://pnpm.io/)
+
 [![Docker](https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)](https://www.docker.com/)
 [![Docker Compose](https://img.shields.io/badge/Docker_Compose-2496ED?style=for-the-badge&logo=docker&logoColor=white)](https://docs.docker.com/compose/)
 [![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-2088FF?style=for-the-badge&logo=github-actions&logoColor=white)](https://github.com/features/actions)
@@ -12,12 +24,12 @@ LLM 呼び出しは LiteLLM Proxy 経由でプロバイダー非依存、観測�
 
 ## サービス
 
-- 🌐 **Frontend**: React SPA（テキスト読み上げ・会話生成・メディア変換の操作画面）
+- 🌐 **Frontend**: React SPA（テキスト読み上げ・チャット履歴・メディア変換の操作画面、モバイル対応 2 ペイン UI）
 - 🐍 **Django API**: REST API で複数の機能を提供するバックエンドサーバ
     - 🔐 **User**: ユーザー認証・管理機能
     - **integrations/** - 外部サービス連携
         - 🤖 **LLM**: LiteLLM Proxy 経由の LLM クライアント（プロバイダー非依存・Langfuse 自動トレース）
-        - 🔭 **Langfuse**: プロンプト管理モデル `LangfusePromptRef`（HN Agent / Talk が参照）
+        - 🔭 **Langfuse**: プロンプト管理モデル `LangfusePromptRef`（HN Agent / Talk が参照）+ Sessions 機能でチャット会話を集約観測
         - 🔗 **MS Graph**: Microsoft Graph API 設定・認証・クライアント
         - ☁️ **OneDrive**: Microsoft OneDrive との統合機能
         - 📅 **Outlook**: Outlook Calendar 予定取得機能
@@ -27,7 +39,7 @@ LLM 呼び出しは LiteLLM Proxy 経由でプロバイダー非依存、観測�
         - 🔍 **Tavily**: Tavily Web 検索 API クライアント
         - 💬 **Slack**: Slack Incoming Webhook 通知クライアント
     - **features/** - ビジネス機能
-        - 🎙️ **Talk**: 会話生成 API（プリセットベース・天気/予定/日時プレースホルダー対応・TTS 統合）
+        - 🎙️ **Talk**: 会話生成 API + **チャット履歴セッション**（DB + ファイル永続化、編集再送、音声配信/個別 & 一括削除、LLM タイトル要約、Langfuse Session 連携）
         - 📁 **Media**: メディア変換（画像フォーマット変換、ZIP → PDF）
         - 🕵️ **HackerNews Agent**: HN 監視・分析エージェント（Watcher → Orchestrator → Detective / Devil's Advocate / Security Responder → Slack 通知。LangGraph ReAct Agent がスレッド性質に応じて 3 ツールを使い分け）
 - 🎤 **Style-BERT-VITS2 API**: 日本語音声合成サービス（GPU）
@@ -106,13 +118,14 @@ Langfuse 未登録でも `LangfusePromptRef.fallback_text` があれば動作し
 ## 特徴
 
 - 🌐 **モダン SPA**: React 19 + TypeScript + Tailwind CSS v4 + shadcn/ui
+- 💬 **チャット履歴永続化**: ChatGPT 風の 2 ペイン UI、編集再送、音声一括再生 / DL（iOS Safari の autoplay にも対応）、モバイルドロワー
 - 🚀 **CI/CD**: GitHub Actions による自動ビルド・テスト・リリース
 - 📦 **コンテナレジストリ**: GitHub Container Registry へのイメージ公開
 - 🔐 **ビルド証明**: SLSA Build Provenance による信頼性の担保
 - 📋 **SBOM**: ソフトウェア部品表（CycloneDX）の自動生成
 - 🛡️ **脆弱性スキャン**: Trivy によるイメージ検査
 - 🔒 **暗号化**: 機密情報の暗号化保存（MS Graph 秘密鍵、LiteLLM Virtual Key など）
-- 🔭 **LLM 観測**: Langfuse によるトレース・プロンプトバージョニング
+- 🔭 **LLM 観測**: Langfuse によるトレース・プロンプトバージョニング・**Sessions** によるチャット集約
 - ✅ **テスト**: pytest（バックエンド）+ Vitest + Playwright（フロントエンド）
 
 ## プロジェクト構成
@@ -133,8 +146,8 @@ kawashiro-server/
 │   ├── src/
 │   │   ├── components/         # UIコンポーネント
 │   │   ├── features/           # 画面（home, login, tts, talk, media）
-│   │   ├── lib/                # APIクライアント
-│   │   └── stores/             # Zustand ストア
+│   │   ├── lib/                # APIクライアント / format / audio 結合
+│   │   └── stores/             # Zustand ストア（auth, tts, chat）
 │   ├── tests/                  # Vitest ユニットテスト
 │   └── e2e/                    # Playwright E2E テスト
 │
@@ -154,10 +167,17 @@ kawashiro-server/
 │   │   ├── tavily/             # Tavily Web 検索クライアント
 │   │   └── slack/              # Slack Incoming Webhook
 │   ├── features/
-│   │   ├── talk/               # Talk Generator（LLM + 天気 + 予定 + TTS）
+│   │   ├── talk/               # Talk Generator + チャット履歴セッション
+│   │   │   ├── views/          # synthesize / sessions / messages / audio に分割
+│   │   │   ├── models.py       # TalkConfig / ChatSession / ChatMessage
+│   │   │   ├── services.py     # synthesize_chat / generate_session_title
+│   │   │   └── signals.py      # post_delete で音声ファイル物理削除
 │   │   ├── media/              # メディア変換
 │   │   └── hn_agent/           # HackerNews Agent
 │   └── tests/                  # テストコード
+│
+├── volumes/
+│   └── media/                  # チャット履歴の TTS 音声永続化先（ホストマウント）
 │
 └── sbv2_api/                   # Style-BERT-VITS2 APIサーバー（GPU / CUDA 11.8）
 ```

--- a/django_api/README.md
+++ b/django_api/README.md
@@ -12,7 +12,7 @@ REST API で複数の機能を提供するバックエンドサーバです。LL
 | media | `/media/` | 画像変換・ZIP→PDF |
 | tts | `/tts/` | テキスト読み上げ（Style-BERT-VITS2 プロキシ） |
 | weather | `/weather/` | 気象庁天気予報 |
-| talk | `/talk/` | 会話生成（Talk Generator） |
+| talk | `/talk/` | 会話生成（Talk Generator）+ チャット履歴セッション API |
 | hn-agent | `/hn-agent/` | HackerNews Agent（監視・調査・辛口分析・セキュリティ対応指針） |
 
 ## アーキテクチャの肝
@@ -239,6 +239,56 @@ Langfuse 上のユーザープロンプトテンプレートで以下のプレ�
 | `{{datetime}}` | 日時・曜日・祝日情報（JSON） | 日時情報を使用 |
 | `{{weather}}` | 天気予報データ（JSON） | 天気情報を使用 |
 | `{{events}}` | 本日の予定データ（JSON） | 予定情報を使用 |
+
+#### チャット履歴セッション API
+
+`TalkConfig` の人格を使い回しつつ、ChatGPT 風に過去発話を引き継いだ複数ターンの会話を行う API 群。データは PostgreSQL に永続化、TTS 音声は `MEDIA_ROOT` 配下にファイルとして保存し、Django ビュー経由で認可付き配信されます。
+
+| メソッド | パス | 用途 |
+|---|---|---|
+| `GET`     | `/talk/sessions/`                                    | セッション一覧（LimitOffsetPagination, default_limit=20） |
+| `POST`    | `/talk/sessions/`                                    | セッション新規作成（`config_name` を作成時に固定） |
+| `GET`     | `/talk/sessions/<uuid>/`                             | 詳細（messages 含む。音声は `audio_url` 経由） |
+| `PATCH`   | `/talk/sessions/<uuid>/`                             | タイトル更新 |
+| `DELETE`  | `/talk/sessions/<uuid>/`                             | セッション削除（音声ファイルも cascade で物理削除） |
+| `POST`    | `/talk/sessions/<uuid>/messages/`                    | ユーザー発話を送信し assistant 応答を生成（throttle: `talk_chat` 20/min） |
+| `PATCH`   | `/talk/sessions/<uuid>/messages/<int>/`              | 編集再送（対象 user メッセージ以降を物理削除し再生成） |
+| `GET`     | `/talk/sessions/<uuid>/audio/<int>/`                 | 認可付き音声 `FileResponse` |
+| `DELETE`  | `/talk/sessions/<uuid>/audio/<int>/`                 | 個別メッセージの音声だけ削除（テキストは残す） |
+| `DELETE`  | `/talk/sessions/<uuid>/audio/`                       | セッション内の音声を一括削除 |
+
+主な特徴:
+
+- **モデル**: `ChatSession`(UUID 主キー / user FK / config_name 固定 / title 自動生成) と `ChatMessage`(`(session, sequence)` UniqueConstraint / FileField)
+- **タイトル LLM 自動生成**: 初回 assistant 応答後に `TalkService.generate_session_title` が 20 文字程度で要約。手動編集も可能
+- **同時 POST 安全**: `select_for_update` で 50 件上限のレース防止
+- **オーファン対策**: `transaction.atomic` の commit 後にファイル書き込み、シグナルで削除時の物理削除
+- **Langfuse Sessions 連携**: 各 LLM 呼び出しトレースに `session_id`（UUID）を付与し、Langfuse UI のセッション機能で同一会話を集約観測
+
+##### API 呼び出し例（チャット履歴）
+
+```bash
+# セッションを新規作成（プリセット = morning に固定）
+curl -X POST http://localhost:8000/talk/sessions/ \
+  -H "Authorization: Token YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"config_name": "morning"}'
+
+# 発話を送信して assistant 応答（音声付き）を取得
+curl -X POST http://localhost:8000/talk/sessions/<uuid>/messages/ \
+  -H "Authorization: Token YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "おはよう"}'
+
+# 音声ファイルを取得（streaming）
+curl http://localhost:8000/talk/sessions/<uuid>/audio/<msg_id>/ \
+  -H "Authorization: Token YOUR_TOKEN" \
+  --output reply.wav
+
+# セッション内の音声を一括削除（テキストは残す）
+curl -X DELETE http://localhost:8000/talk/sessions/<uuid>/audio/ \
+  -H "Authorization: Token YOUR_TOKEN"
+```
 
 ### HackerNews Agent API
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -24,7 +24,7 @@
 | `/login`    | ログイン           | メールアドレス + パスワードでToken認証     |
 | `/`         | ホーム             | バナー + メニューカード                    |
 | `/tts`      | テキスト読み上げ   | テキスト入力 → 音声合成 → 再生/ダウンロード |
-| `/talk`     | 会話生成読み上げ     | プリセット選択 → LLM生成 → TTS再生        |
+| `/talk`     | チャット（履歴あり）| 2 ペイン UI（左 = セッション一覧、右 = メッセージ）。プリセット選択して新規セッション作成、過去会話を引き継いだ複数ターン会話、編集再送、音声個別/一括 再生・DL・削除、LLM タイトル自動生成。モバイルではドロワー化、iOS Safari の autoplay にも対応 |
 | `/media`    | メディア変換       | 画像フォーマット変換 / ZIP→PDF変換         |
 
 ## セットアップ
@@ -111,12 +111,24 @@ frontend/
 │   │   ├── home/                # ホーム画面
 │   │   ├── login/               # ログイン画面
 │   │   ├── tts/                 # テキスト読み上げ
-│   │   ├── talk/                # 会話生成読み上げ
+│   │   ├── talk/                # チャット履歴 UI
+│   │   │   ├── ChatPage.tsx              # 2 ペイン構成（sidebar + main）
+│   │   │   ├── SessionSidebar.tsx        # 履歴一覧 + モバイルドロワー
+│   │   │   ├── SessionListItem.tsx       # タイトル / 日時 / サイズ / 削除
+│   │   │   ├── NewSessionDialog.tsx      # プリセット選択モーダル
+│   │   │   ├── SessionTitleEditor.tsx    # タイトルのインライン編集
+│   │   │   ├── ChatThreadView.tsx        # メッセージ一覧 + 入力欄 + ツールバー
+│   │   │   ├── ChatMessageItem.tsx       # メッセージ + 編集再送 + 音声 UI
+│   │   │   ├── ChatInputForm.tsx         # 送信 / 停止 (キャンセル) ボタン
+│   │   │   ├── AudioBundlePlay.tsx       # 一括再生（4 状態, iOS Safari 対応）
+│   │   │   └── AudioBundleDownload.tsx   # 一括 DL（WAV を 1 秒無音入りで結合）
 │   │   └── media/               # メディア変換
 │   ├── lib/
 │   │   ├── api-client.ts        # ky インスタンス（Auth自動付与）
-│   │   └── api/                 # API 関数（auth, tts, talk, media）
-│   ├── stores/                  # Zustand ストア（auth, tts）
+│   │   ├── api/                 # API 関数（auth, tts, talk, media）
+│   │   ├── audio/               # concat / bundleLoader（音声結合・取得）
+│   │   └── format/              # bytes ヘルパ
+│   ├── stores/                  # Zustand ストア（auth, tts, chat）
 │   └── types/                   # TypeScript 型定義
 ├── tests/                       # Vitest ユニットテスト
 ├── e2e/                         # Playwright E2E テスト


### PR DESCRIPTION
## Summary

PR #222 を develop に統合した内容を main へリリースします。本リリースは README 3 ファイルのみのドキュメント変更で、コード・依存関係・マイグレーションへの影響はありません。

### 変更内容

- **ルート README**:
  - 上部にキャッチコピーブロックを追加（Docker × Django × React の構成と LiteLLM/Langfuse・チャット履歴・OneDrive/Outlook の要約）
  - バッジを Python 3.13 / Django 6 / React 19 / TypeScript / Vite / Tailwind v4 / PostgreSQL 17 / pnpm に拡充
  - サービス概要・特徴・プロジェクト構成をチャット履歴機能 (PR #221) に追従
- **django_api/README**:
  - 機能一覧の talk 行を「会話生成 + チャット履歴セッション API」へ
  - Talk Generator 章末に「チャット履歴セッション API」サブセクションを新設
    - 10 エンドポイントの一覧（CRUD / メッセージ送受信 / 編集再送 / 音声配信 / 個別 & 一括音声削除）
    - モデル / タイトル LLM 自動生成 / 同時 POST 安全 / オーファン対策 / Langfuse Sessions 連携の要約
    - curl 呼び出し例 4 種
- **frontend/README**:
  - 画面構成 `/talk` を「チャット（履歴あり）」に書き換え
  - ディレクトリ構成に features/talk 配下の 10 コンポーネント、lib/audio・lib/format、stores/chat を明示
- 無関係な `weather/README.md` と `hn_agent/README.md` は変更なし

## Test plan

- [ ] release.yml が完走（README のみのため verify-images / tag-release は変更なしでも通過する想定）
- [ ] GitHub 上でレンダリングを再確認