### PR TITLE
feat(media): zip-to-pdf の出力ファイル名を元ZIP名に揃える

### DIFF
--- a/django_api/features/media/views.py
+++ b/django_api/features/media/views.py
@@ -2,8 +2,12 @@
 
 import io
 import logging
+import os
+import re
 import zipfile
 from datetime import datetime
+from pathlib import PurePosixPath
+from urllib.parse import quote
 from zoneinfo import ZoneInfo
 
 from django.conf import settings
@@ -25,6 +29,40 @@ except ImportError:
     pass
 
 logger = logging.getLogger(__name__)
+
+
+def build_pdf_filename(uploaded_name: str | None) -> str:
+    """
+    アップロードファイル名から安全なPDFファイル名を生成
+
+    パス区切り、制御文字、ダブルクォート、バックスラッシュなどHTTPヘッダ
+    インジェクションに繋がりうる文字を除去した上で、拡張子を .pdf に置換する。
+    """
+    fallback = "converted.pdf"
+    if not uploaded_name:
+        return fallback
+    # Windows / POSIX どちらの区切りも除去（パストラバーサル対策）
+    base = os.path.basename(uploaded_name.replace("\\", "/"))
+    stem = PurePosixPath(base).stem
+    # 制御文字・改行・ダブルクォート・バックスラッシュを除去
+    stem = re.sub(r'[\r\n"\\\x00-\x1f\x7f]', "", stem).strip()
+    if not stem:
+        return fallback
+    return f"{stem}.pdf"
+
+
+def build_attachment_disposition(filename: str) -> str:
+    """
+    Content-Disposition ヘッダ値を生成（RFC 6266 / RFC 5987 準拠）
+
+    ASCII フォールバック（filename）と UTF-8 エンコード版（filename*）の
+    両方を含めることで、日本語ファイル名でも対応ブラウザで正しく扱える。
+    """
+    ascii_fallback = (
+        filename.encode("ascii", errors="replace").decode("ascii").replace("?", "_")
+    )
+    encoded = quote(filename, safe="")
+    return f"attachment; filename=\"{ascii_fallback}\"; filename*=UTF-8''{encoded}"
 
 
 def is_safe_image_file(filename: str, image_extensions: tuple) -> bool:
@@ -195,7 +233,10 @@ class ZipToPdfView(APIView):
                 response = HttpResponse(
                     pdf_buffer.getvalue(), content_type="application/pdf"
                 )
-                response["Content-Disposition"] = 'attachment; filename="converted.pdf"'
+                pdf_filename = build_pdf_filename(uploaded_file.name)
+                response["Content-Disposition"] = build_attachment_disposition(
+                    pdf_filename
+                )
                 return response
 
         except zipfile.BadZipFile:

--- a/django_api/tests/features/media/test_views.py
+++ b/django_api/tests/features/media/test_views.py
@@ -300,9 +300,7 @@ class TestZipToPdfView:
         # ASCIIフォールバックには元の文字（スペース・括弧含む）がそのまま入る
         assert 'filename="my-file_v2 (final) [draft].pdf"' in disposition
         # RFC 5987 はパーセントエンコード済み
-        assert (
-            "my-file_v2%20%28final%29%20%5Bdraft%5D.pdf" in disposition
-        )
+        assert "my-file_v2%20%28final%29%20%5Bdraft%5D.pdf" in disposition
 
     def test_pdf_filename_strips_path_traversal(
         self, authenticated_client, create_zip_file

--- a/django_api/tests/features/media/test_views.py
+++ b/django_api/tests/features/media/test_views.py
@@ -53,13 +53,14 @@ def setup_heif_support():
 def create_zip_file(create_test_image):
     """テスト用のZIPファイルを作成するヘルパー関数"""
 
-    def _create_zip(files):
+    def _create_zip(files, zip_name="test.zip"):
         """
         ファイルを含むZIPファイルを作成
 
         Args:
             files: ファイルのリスト [{'name': 'file.jpg', 'format': 'JPEG', 'color': 'red'}, ...]
                    または [{'name': 'file.txt', 'content': b'text content'}, ...]
+            zip_name: アップロードファイル名（デフォルト: "test.zip"）
 
         Returns:
             SimpleUploadedFile: ZIPファイルオブジェクト
@@ -80,7 +81,7 @@ def create_zip_file(create_test_image):
 
         zip_io.seek(0)
         return SimpleUploadedFile(
-            name="test.zip", content=zip_io.read(), content_type="application/zip"
+            name=zip_name, content=zip_io.read(), content_type="application/zip"
         )
 
     return _create_zip
@@ -225,6 +226,104 @@ class TestZipToPdfView:
 
         assert response.status_code == status.HTTP_200_OK
         assert response["Content-Type"] == "application/pdf"
+
+    def test_pdf_filename_matches_uploaded_zip(
+        self, authenticated_client, create_zip_file
+    ):
+        """変換後のPDFファイル名がアップロードされたZIPの名前（拡張子.pdf）になること"""
+        zip_file = create_zip_file(
+            [{"name": "image.jpg", "format": "JPEG", "color": "red"}],
+            zip_name="aaa.zip",
+        )
+
+        payload = {"file": zip_file}
+        response = authenticated_client.post(
+            "/media/zip-to-pdf/", payload, format="multipart"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert 'filename="aaa.pdf"' in response["Content-Disposition"]
+
+    def test_pdf_filename_preserves_inner_dots(
+        self, authenticated_client, create_zip_file
+    ):
+        """ドットを複数含むZIP名は最後の拡張子のみ.pdfに置換されること"""
+        zip_file = create_zip_file(
+            [{"name": "image.jpg", "format": "JPEG", "color": "red"}],
+            zip_name="my.archive.v2.zip",
+        )
+
+        payload = {"file": zip_file}
+        response = authenticated_client.post(
+            "/media/zip-to-pdf/", payload, format="multipart"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert 'filename="my.archive.v2.pdf"' in response["Content-Disposition"]
+
+    def test_pdf_filename_with_japanese_uses_rfc5987(
+        self, authenticated_client, create_zip_file
+    ):
+        """日本語ZIP名の場合、RFC 5987形式（filename*=UTF-8''...）が含まれること"""
+        zip_file = create_zip_file(
+            [{"name": "image.jpg", "format": "JPEG", "color": "red"}],
+            zip_name="あいうえお.zip",
+        )
+
+        payload = {"file": zip_file}
+        response = authenticated_client.post(
+            "/media/zip-to-pdf/", payload, format="multipart"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        disposition = response["Content-Disposition"]
+        # RFC 5987 形式のパーセントエンコードされたファイル名
+        assert "filename*=UTF-8''" in disposition
+        assert "%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A.pdf" in disposition
+
+    def test_pdf_filename_preserves_spaces_and_symbols(
+        self, authenticated_client, create_zip_file
+    ):
+        """半角スペース・括弧・ハイフン等の記号を含むZIP名がそのまま保持されること"""
+        zip_file = create_zip_file(
+            [{"name": "image.jpg", "format": "JPEG", "color": "red"}],
+            zip_name="my-file_v2 (final) [draft].zip",
+        )
+
+        payload = {"file": zip_file}
+        response = authenticated_client.post(
+            "/media/zip-to-pdf/", payload, format="multipart"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        disposition = response["Content-Disposition"]
+        # ASCIIフォールバックには元の文字（スペース・括弧含む）がそのまま入る
+        assert 'filename="my-file_v2 (final) [draft].pdf"' in disposition
+        # RFC 5987 はパーセントエンコード済み
+        assert (
+            "my-file_v2%20%28final%29%20%5Bdraft%5D.pdf" in disposition
+        )
+
+    def test_pdf_filename_strips_path_traversal(
+        self, authenticated_client, create_zip_file
+    ):
+        """ZIP名にパス区切りが含まれてもbasenameのみが使われること"""
+        zip_file = create_zip_file(
+            [{"name": "image.jpg", "format": "JPEG", "color": "red"}],
+            zip_name="../../etc/passwd.zip",
+        )
+
+        payload = {"file": zip_file}
+        response = authenticated_client.post(
+            "/media/zip-to-pdf/", payload, format="multipart"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        disposition = response["Content-Disposition"]
+        assert 'filename="passwd.pdf"' in disposition
+        # パス成分が漏れていないこと
+        assert ".." not in disposition
+        assert "/" not in disposition.split("filename=", 1)[1].split(";", 1)[0]
 
 
 @pytest.mark.api

--- a/frontend/src/lib/api/media.ts
+++ b/frontend/src/lib/api/media.ts
@@ -11,6 +11,17 @@ function extractFilename(
     fallback: string,
 ): string {
     if (!contentDisposition) return fallback;
+    // RFC 5987: filename*=UTF-8''<percent-encoded> を ASCII フォールバックより優先
+    const utf8Match = contentDisposition.match(
+        /filename\*\s*=\s*UTF-8''([^;]+)/i,
+    );
+    if (utf8Match) {
+        try {
+            return decodeURIComponent(utf8Match[1].trim());
+        } catch {
+            // 不正なパーセントエンコードの場合は ASCII フォールバックへ
+        }
+    }
     const match = contentDisposition.match(/filename="?([^";\s]+)"?/);
     return match ? match[1] : fallback;
 }

--- a/frontend/tests/lib/api/media.test.ts
+++ b/frontend/tests/lib/api/media.test.ts
@@ -59,4 +59,48 @@ describe('Media API', () => {
         expect(result.blob.size).toBeGreaterThan(0);
         expect(result.filename).toBe('converted.pdf');
     });
+
+    it('半角スペース・括弧・記号を含むファイル名も filename* からデコードできる', async () => {
+        server.use(
+            http.post('*/api/media/zip-to-pdf/', () => {
+                return new HttpResponse('fake-pdf-data', {
+                    status: 200,
+                    headers: {
+                        'Content-Type': 'application/pdf',
+                        'Content-Disposition':
+                            "attachment; filename=\"my-file_v2 (final) [draft].pdf\"; filename*=UTF-8''my-file_v2%20%28final%29%20%5Bdraft%5D.pdf",
+                    },
+                });
+            }),
+        );
+
+        const file = new File(['test'], 'my-file_v2 (final) [draft].zip', {
+            type: 'application/zip',
+        });
+        const result = await zipToPdf(file);
+
+        expect(result.filename).toBe('my-file_v2 (final) [draft].pdf');
+    });
+
+    it('ZIP→PDFのファイル名は RFC 5987 (filename*=UTF-8\'\'…) を優先して日本語をデコードする', async () => {
+        server.use(
+            http.post('*/api/media/zip-to-pdf/', () => {
+                return new HttpResponse('fake-pdf-data', {
+                    status: 200,
+                    headers: {
+                        'Content-Type': 'application/pdf',
+                        'Content-Disposition':
+                            "attachment; filename=\"_____.pdf\"; filename*=UTF-8''%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A.pdf",
+                    },
+                });
+            }),
+        );
+
+        const file = new File(['test'], 'あいうえお.zip', {
+            type: 'application/zip',
+        });
+        const result = await zipToPdf(file);
+
+        expect(result.filename).toBe('あいうえお.pdf');
+    });
 });


### PR DESCRIPTION
## Summary

- ZIP→PDF 変換 (`/media/zip-to-pdf/`) のダウンロードファイル名を、固定の `converted.pdf` から元ZIP名 + `.pdf` に変更（例: `aaa.zip` → `aaa.pdf`）
- 日本語ファイル名・半角スペース・記号にも対応するため、サーバーで RFC 6266 / 5987 準拠の `Content-Disposition`（ASCII fallback + `filename*=UTF-8''…` 併記）を返すヘルパーを追加
- フロントの `extractFilename` を `filename*=UTF-8''…` 優先抽出に修正

## 変更点

### Backend (`django_api/features/media/views.py`)

- `build_pdf_filename(uploaded_name)`：パストラバーサル対策（`os.path.basename` + `\` 正規化）+ HTTP ヘッダインジェクション対策（制御文字・改行・`"`・`\` を除去）+ 拡張子置換 + 空名フォールバック (`converted.pdf`)
- `build_attachment_disposition(filename)`：ASCII fallback (`filename="..."`) と RFC 5987 (`filename*=UTF-8''<percent-encoded>`) を併記
- `ZipToPdfView.post`：上記ヘルパー経由で `Content-Disposition` をセット

### Frontend (`frontend/src/lib/api/media.ts`)

- `extractFilename`：`filename*=UTF-8''<percent-encoded>` を ASCII fallback より優先抽出して `decodeURIComponent`、失敗時は ASCII fallback に黙って後退

### テスト

- バックエンド `TestZipToPdfView` に5件追加：通常名 (`aaa.zip`→`aaa.pdf`)、複数ドット (`my.archive.v2.zip`)、日本語 (`あいうえお.zip`)、半角スペース・記号 (`my-file_v2 (final) [draft].zip`)、パストラバーサル (`../../etc/passwd.zip`)
- フロント `Media API` に2件追加：日本語名・半角スペース＋記号
- `create_zip_file` フィクスチャに `zip_name` 引数を追加（既定値 `"test.zip"` で既存テストへの影響なし）

## Test plan

- [x] バックエンド `TestZipToPdfView` 13件パス
- [x] バックエンド全 614 テスト回帰なし
- [x] フロント `Media API` 4件パス（vitest 全 57 件パス）
- [x] `ruff format/check` クリア
- [x] フロント `type-check` / `lint` エラーなし
- [x] code-reviewer エージェントで CRITICAL/HIGH 0件確認（APPROVE 判定）
- [x] ステージング環境で実機ダウンロード確認