### PR TITLE
fix(talk): 音声実体喪失時に 404 を返す + media 永続化マウント整理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-# 永続化ボリューム（ディレクトリ構造は.gitkeepで維持）
-/volumes/**/*
-!/volumes/**/
-!/volumes/**/.gitkeep
-
 # OS関連
 .DS_Store
 Thumbs.db

--- a/django_api/features/talk/management/commands/cleanup_orphan_audio.py
+++ b/django_api/features/talk/management/commands/cleanup_orphan_audio.py
@@ -1,0 +1,53 @@
+"""DB 上 audio_file パスは残るが実体ファイルが無い ChatMessage を整理する."""
+
+from django.core.management.base import BaseCommand
+
+from features.talk.models import ChatMessage
+
+
+class Command(BaseCommand):
+    help = (
+        "ChatMessage.audio_file が指す実体ファイルが存在しないレコードを検出し、"
+        "audio_file / audio_format / audio_size_bytes をクリアする"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="DB を更新せず、対象件数とパスのみ表示する",
+        )
+
+    def handle(self, *args, dry_run: bool = False, **options):
+        qs = ChatMessage.objects.exclude(audio_file="")
+        orphans: list[ChatMessage] = []
+        for msg in qs.iterator():
+            name = msg.audio_file.name
+            try:
+                exists = bool(name) and msg.audio_file.storage.exists(name)
+            except (ValueError, NotImplementedError):
+                exists = False
+            if not exists:
+                orphans.append(msg)
+
+        if not orphans:
+            self.stdout.write("孤児となった音声レコードはありません。")
+            return
+
+        if dry_run:
+            self.stdout.write(
+                f"[dry-run] {len(orphans)} 件の孤児レコードをクリア対象として検出"
+            )
+            for msg in orphans:
+                self.stdout.write(
+                    f"  - id={msg.id} session={msg.session_id} "
+                    f"path={msg.audio_file.name}"
+                )
+            return
+
+        for msg in orphans:
+            msg.audio_file = None
+            msg.audio_format = ""
+            msg.audio_size_bytes = 0
+            msg.save(update_fields=["audio_file", "audio_format", "audio_size_bytes"])
+        self.stdout.write(f"{len(orphans)} 件の孤児レコードをクリアしました。")

--- a/django_api/features/talk/views/audio.py
+++ b/django_api/features/talk/views/audio.py
@@ -41,9 +41,14 @@ class ChatSessionMessageAudioView(APIView):
         msg = self._get_message(request, session_id, msg_id)
         if not msg.audio_file:
             return Response(status=status.HTTP_404_NOT_FOUND)
+        # ボリューム喪失等で DB 行は残っているが実体が消えているケースを 404 化
+        # （素直に open すると FileNotFoundError → 500 になる）
+        name = msg.audio_file.name
+        if not name or not msg.audio_file.storage.exists(name):
+            return Response(status=status.HTTP_404_NOT_FOUND)
         content_type = _AUDIO_CONTENT_TYPE.get(
             msg.audio_format,
-            mimetypes.guess_type(msg.audio_file.name)[0] or "application/octet-stream",
+            mimetypes.guess_type(name)[0] or "application/octet-stream",
         )
         return FileResponse(msg.audio_file.open("rb"), content_type=content_type)
 

--- a/django_api/tests/features/talk/test_cleanup_orphan_audio.py
+++ b/django_api/tests/features/talk/test_cleanup_orphan_audio.py
@@ -1,0 +1,80 @@
+"""cleanup_orphan_audio 管理コマンドのテスト."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.files.base import ContentFile
+from django.core.management import call_command
+
+from features.talk.models import ChatMessage, ChatSession
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(
+        email="cleanup-audio@example.com",
+        password="dummypass1234",
+    )
+
+
+def _make_message_with_audio(user, sequence: int = 1) -> ChatMessage:
+    session = ChatSession.objects.create(user=user, config_name="m")
+    msg = ChatMessage(
+        session=session,
+        sequence=sequence,
+        role="assistant",
+        content="hello",
+        audio_format="wav",
+        audio_size_bytes=20,
+    )
+    msg.audio_file.save(f"{sequence}.wav", ContentFile(b"\x01" * 20), save=True)
+    return msg
+
+
+@pytest.mark.django_db
+class TestCleanupOrphanAudio:
+    def test_keeps_records_with_existing_files(self, user):
+        msg = _make_message_with_audio(user)
+        call_command("cleanup_orphan_audio")
+        msg.refresh_from_db()
+        assert bool(msg.audio_file)
+        assert msg.audio_format == "wav"
+        assert msg.audio_size_bytes == 20
+
+    def test_clears_orphan_records(self, user):
+        msg = _make_message_with_audio(user)
+        # 実体ファイルだけ削除し DB 行は残す（本番事故と同条件）
+        msg.audio_file.storage.delete(msg.audio_file.name)
+
+        call_command("cleanup_orphan_audio")
+
+        msg.refresh_from_db()
+        assert not msg.audio_file
+        assert msg.audio_format == ""
+        assert msg.audio_size_bytes == 0
+
+    def test_dry_run_does_not_modify_db(self, user):
+        msg = _make_message_with_audio(user)
+        msg.audio_file.storage.delete(msg.audio_file.name)
+        original_name = msg.audio_file.name
+        original_format = msg.audio_format
+        original_size = msg.audio_size_bytes
+
+        call_command("cleanup_orphan_audio", "--dry-run")
+
+        msg.refresh_from_db()
+        assert msg.audio_file.name == original_name
+        assert msg.audio_format == original_format
+        assert msg.audio_size_bytes == original_size
+
+    def test_skips_records_without_audio(self, user):
+        session = ChatSession.objects.create(user=user, config_name="m")
+        ChatMessage.objects.create(
+            session=session, sequence=0, role="user", content="hi"
+        )
+
+        call_command("cleanup_orphan_audio")
+
+        # 例外なく完了し、対象外レコードに副作用がないこと
+        assert ChatMessage.objects.count() == 1

--- a/django_api/tests/features/talk/test_session_audio_views.py
+++ b/django_api/tests/features/talk/test_session_audio_views.py
@@ -92,6 +92,16 @@ class TestAudioGet:
         response = auth_client.get(_audio_url(session.id, msg.id))
         assert response.status_code == 404
 
+    def test_storage_missing_returns_404(self, session_with_audio, auth_client):
+        """DB には audio_file パスが残るが実体ファイルが消えていれば 404."""
+        session, msg = session_with_audio
+        # ボリューム喪失等で実体だけ消えた状況を再現（DB 行はそのまま）
+        msg.audio_file.storage.delete(msg.audio_file.name)
+
+        response = auth_client.get(_audio_url(session.id, msg.id))
+
+        assert response.status_code == 404
+
 
 @pytest.mark.django_db
 class TestAudioDeleteIndividual:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
             # 静的ファイルの永続化
             - /opt/app/django-api/staticfiles:/django_api/staticfiles
             # メディアファイル（チャット履歴の TTS 音声など）の永続化
-            - ./volumes/media:/django_api/media
+            - /opt/app/django-api/media:/django_api/media
         restart: unless-stopped
         networks:
             - container-network


### PR DESCRIPTION
## 概要

本番で media ボリュームが未マウントだったため、コンテナ再作成で TTS 音声ファイルが消失し、`/talk/sessions/<id>/audio/<msg_id>/` で 500 が返っていた問題の対応。

DB 上の `ChatMessage.audio_file` パスは残っていたが、実体不在で `FileResponse(.open("rb"))` が `FileNotFoundError` を投げ 500 → ユーザー側で「音声の取得に失敗しました」表示。

## 修正内容

- `ChatSessionMessageAudioView.get` で `storage.exists()` を事前確認し、実体不在時は 500 ではなく **404** を返す
- DB 上の孤児レコード（`audio_file` パスは残るが実体不在）を一括クリアする **`cleanup_orphan_audio`** 管理コマンドを追加（`--dry-run` 対応）
- 開発用 `docker-compose.yml` の media マウント先を staticfiles と揃えて **`/opt/app/django-api/media`** に変更
- 旧 `./volumes/` 永続化ディレクトリを廃止（`.gitignore` も整理）
- 関連テスト 5 ケース追加（404 防御 1 + 孤児整理 4）

## 関連インフラ修正

本番 compose テンプレート（internal.kagiyama.net の Ansible）は別途修正済みで、適用後は `/opt/app/django-api/media` を bind mount する。

## Test plan

- [x] talk テスト関連 13 件 全 PASS
- [x] ローカル: コンテナ再作成 → mount 反映確認 (`docker inspect`)
- [x] ローカル: 永続化（ホスト書き込み → restart → 読み取り）確認
- [x] ローカル: `cleanup_orphan_audio` で 11 件クリア → 再 dry-run で 0 件確認（idempotent）
- [x] ローカル: 孤児レコードへの GET が 404 を返すこと（curl）
- [ ] CI（pr-checks.yml）通過確認
- [ ] develop マージ → staging イメージビルド確認
- [ ] main マージ → release CD 後、本番で残存孤児（22 件）を `cleanup_orphan_audio` で整理

## ChatMessage の影響範囲

`audio_file` / `audio_format` / `audio_size_bytes` の 3 フィールドのみクリア。テキスト本体（`content`）は維持される。