### PR TITLE
release: ZIP→PDF 本番OOM修正と原因特定の改善 (#230)

### DIFF
--- a/django_api/features/media/views.py
+++ b/django_api/features/media/views.py
@@ -102,9 +102,11 @@ class ZipToPdfView(APIView):
     # ZIPボム対策の制限値
     MAX_TOTAL_SIZE = 1 * 1024 * 1024 * 1024  # 1GB（展開後の合計サイズ）
     MAX_FILES = 1000
-    # PDF化時の合計メガピクセル数の上限（本番のメモリ枠 512MiB を守るための事前ガード）
-    # 1MP の RGB 画像 ≈ 3MB。200MP で約 600MB の理論ピーク相当。
-    MAX_TOTAL_MEGAPIXELS = 200.0
+    # 1 枚あたりのメガピクセル上限。
+    # img2pdf は JPEG をそのまま埋め込むため合計サイズで縛る必要はないが、
+    # PNG/WEBP は 1 枚ずつ Pillow で RGB に展開するため、その瞬間のメモリピークを
+    # 本番 mem_limit (512MiB) に収めるためのガード。100MP ≈ 300MB の RGB バッファ。
+    MAX_PER_IMAGE_MEGAPIXELS = 100.0
 
     # img2pdf にそのまま埋め込める拡張子（再エンコード不要）
     NATIVE_PDF_EMBED_EXTENSIONS = (".jpg", ".jpeg")
@@ -212,22 +214,23 @@ class ZipToPdfView(APIView):
                         status=status.HTTP_400_BAD_REQUEST,
                     )
 
-                # 事前バリデーション: 合計メガピクセル数の概算で本番OOMを防ぐ
-                total_megapixels = self._estimate_total_megapixels(
-                    zip_ref, image_files
-                )
-                if total_megapixels > self.MAX_TOTAL_MEGAPIXELS:
+                # 事前バリデーション: 1 枚あたりのメガピクセル数で本番OOMを防ぐ
+                # （合計ではなく単一画像の上限。img2pdf は JPEG をそのまま埋め込むため
+                #  合計で縛ると本来通せる漫画スキャン等を弾いてしまう）
+                oversized = self._find_oversized_image(zip_ref, image_files)
+                if oversized is not None:
+                    name, megapixels = oversized
                     logger.warning(
-                        "ZIP→PDF: 合計メガピクセル数が上限超過 "
-                        f"({total_megapixels:.1f}MP > {self.MAX_TOTAL_MEGAPIXELS}MP)"
+                        "ZIP→PDF: 単一画像のメガピクセル数が上限超過 "
+                        f"({name}: {megapixels:.1f}MP > {self.MAX_PER_IMAGE_MEGAPIXELS}MP)"
                     )
                     return Response(
                         {
                             "error": (
-                                "ZIP内画像の合計解像度が大きすぎます "
-                                f"（{total_megapixels:.1f}メガピクセル, "
-                                f"上限 {self.MAX_TOTAL_MEGAPIXELS:.0f}メガピクセル）。"
-                                "枚数を減らすか、各画像のサイズを小さくしてください。"
+                                f"ZIP内の画像 '{name}' の解像度が大きすぎます "
+                                f"（{megapixels:.1f}メガピクセル, "
+                                f"1枚あたり上限 {self.MAX_PER_IMAGE_MEGAPIXELS:.0f}メガピクセル）。"
+                                "サイズを小さくしてから再試行してください。"
                             )
                         },
                         status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
@@ -288,21 +291,24 @@ class ZipToPdfView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-    def _estimate_total_megapixels(
+    def _find_oversized_image(
         self, zip_ref: zipfile.ZipFile, image_files: list[str]
-    ) -> float:
-        """ZIP内画像の合計メガピクセル数を概算する。
+    ) -> tuple[str, float] | None:
+        """ZIP 内に MAX_PER_IMAGE_MEGAPIXELS を超える画像があれば最初の 1 件を返す。
 
         Pillow は画像ヘッダだけ読めば size を返すため、ピクセルデータ全体を
         メモリにロードせずに済む。
         """
-        total = 0
         for name in image_files:
-            with zip_ref.open(name) as img_file:
-                with Image.open(img_file) as img:
-                    width, height = img.size
-                    total += width * height
-        return total / 1_000_000
+            with (
+                zip_ref.open(name) as img_file,
+                Image.open(img_file) as img,
+            ):
+                width, height = img.size
+                megapixels = (width * height) / 1_000_000
+                if megapixels > self.MAX_PER_IMAGE_MEGAPIXELS:
+                    return name, megapixels
+        return None
 
     def _collect_pdf_inputs(
         self, zip_ref: zipfile.ZipFile, image_files: list[str]

--- a/django_api/features/media/views.py
+++ b/django_api/features/media/views.py
@@ -10,6 +10,7 @@ from pathlib import PurePosixPath
 from urllib.parse import quote
 from zoneinfo import ZoneInfo
 
+import img2pdf
 from django.conf import settings
 from django.http import HttpResponse
 from drf_spectacular.utils import extend_schema
@@ -101,6 +102,12 @@ class ZipToPdfView(APIView):
     # ZIPボム対策の制限値
     MAX_TOTAL_SIZE = 1 * 1024 * 1024 * 1024  # 1GB（展開後の合計サイズ）
     MAX_FILES = 1000
+    # PDF化時の合計メガピクセル数の上限（本番のメモリ枠 512MiB を守るための事前ガード）
+    # 1MP の RGB 画像 ≈ 3MB。200MP で約 600MB の理論ピーク相当。
+    MAX_TOTAL_MEGAPIXELS = 200.0
+
+    # img2pdf にそのまま埋め込める拡張子（再エンコード不要）
+    NATIVE_PDF_EMBED_EXTENSIONS = (".jpg", ".jpeg")
 
     # 対応する画像拡張子
     IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".webp")
@@ -205,34 +212,35 @@ class ZipToPdfView(APIView):
                         status=status.HTTP_400_BAD_REQUEST,
                     )
 
-                # 画像をPIL Imageオブジェクトに変換
-                # コンテキストマネージャーを使用してメモリリークを防ぐ
-                images = []
-                for image_file in image_files:
-                    with zip_ref.open(image_file) as img_file:
-                        img_data = img_file.read()
-                        with Image.open(io.BytesIO(img_data)) as img:
-                            # RGBモードに変換（PDFにする際に必要）
-                            if img.mode != "RGB":
-                                img = img.convert("RGB")
-                            # 画像をコピーしてから追加（元の画像はwith句を抜けた時点でclose）
-                            images.append(img.copy())
-
-                # PDFに変換
-                pdf_buffer = io.BytesIO()
-                # 最初の画像をベースにして、残りを追加
-                images[0].save(
-                    pdf_buffer,
-                    format="PDF",
-                    save_all=True,
-                    append_images=images[1:] if len(images) > 1 else [],
+                # 事前バリデーション: 合計メガピクセル数の概算で本番OOMを防ぐ
+                total_megapixels = self._estimate_total_megapixels(
+                    zip_ref, image_files
                 )
-                pdf_buffer.seek(0)
+                if total_megapixels > self.MAX_TOTAL_MEGAPIXELS:
+                    logger.warning(
+                        "ZIP→PDF: 合計メガピクセル数が上限超過 "
+                        f"({total_megapixels:.1f}MP > {self.MAX_TOTAL_MEGAPIXELS}MP)"
+                    )
+                    return Response(
+                        {
+                            "error": (
+                                "ZIP内画像の合計解像度が大きすぎます "
+                                f"（{total_megapixels:.1f}メガピクセル, "
+                                f"上限 {self.MAX_TOTAL_MEGAPIXELS:.0f}メガピクセル）。"
+                                "枚数を減らすか、各画像のサイズを小さくしてください。"
+                            )
+                        },
+                        status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    )
 
-                # PDFファイルとしてレスポンスを返す
-                response = HttpResponse(
-                    pdf_buffer.getvalue(), content_type="application/pdf"
-                )
+                # 各画像を 1 枚ずつ処理し、img2pdf に渡せる bytes リストを構築
+                # （PIL Image オブジェクトを画像枚数ぶん同時に保持しない）
+                pdf_inputs = self._collect_pdf_inputs(zip_ref, image_files)
+
+                # img2pdf でストリーミング書き出し（JPEGは無圧縮埋め込み）
+                pdf_bytes = img2pdf.convert(pdf_inputs)
+
+                response = HttpResponse(pdf_bytes, content_type="application/pdf")
                 pdf_filename = build_pdf_filename(uploaded_file.name)
                 response["Content-Disposition"] = build_attachment_disposition(
                     pdf_filename
@@ -245,6 +253,24 @@ class ZipToPdfView(APIView):
                     "error": "アップロードされたファイルは有効なZIPファイルではありません"
                 },
                 status=status.HTTP_400_BAD_REQUEST,
+            )
+        except Image.DecompressionBombError as e:
+            logger.warning(f"ZIP→PDF: Decompression Bomb 検出: {str(e)}")
+            return Response(
+                {
+                    "error": "ZIP内に解像度が大きすぎる画像が含まれています（Decompression Bomb 対策）"
+                },
+                status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            )
+        except MemoryError:
+            # 本番の mem_limit (512MiB) で発生するケース。
+            # 汎用エラーに潰さず原因が分かるメッセージを返す。
+            logger.error("ZIP→PDF: 変換中にメモリ不足が発生", exc_info=True)
+            return Response(
+                {
+                    "error": "サーバーのメモリが不足しました。画像の枚数を減らすか、解像度を下げて再試行してください"
+                },
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
         except (OSError, Image.UnidentifiedImageError) as e:
             # 画像形式エラー
@@ -261,6 +287,53 @@ class ZipToPdfView(APIView):
                 {"error": "画像の処理中にエラーが発生しました"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+    def _estimate_total_megapixels(
+        self, zip_ref: zipfile.ZipFile, image_files: list[str]
+    ) -> float:
+        """ZIP内画像の合計メガピクセル数を概算する。
+
+        Pillow は画像ヘッダだけ読めば size を返すため、ピクセルデータ全体を
+        メモリにロードせずに済む。
+        """
+        total = 0
+        for name in image_files:
+            with zip_ref.open(name) as img_file:
+                with Image.open(img_file) as img:
+                    width, height = img.size
+                    total += width * height
+        return total / 1_000_000
+
+    def _collect_pdf_inputs(
+        self, zip_ref: zipfile.ZipFile, image_files: list[str]
+    ) -> list[bytes]:
+        """img2pdf に渡す画像 bytes のリストを 1 枚ずつ構築する。
+
+        - JPEG はそのまま埋め込み（再エンコード不要・メモリ効率最大）
+        - PNG/WEBP は Pillow で 1 枚ずつ JPEG に変換し、その bytes だけ保持する
+          （PIL Image オブジェクトを画像枚数ぶん同時に保持しない）
+        """
+        pdf_inputs: list[bytes] = []
+        for name in image_files:
+            with zip_ref.open(name) as img_file:
+                raw = img_file.read()
+            if name.lower().endswith(self.NATIVE_PDF_EMBED_EXTENSIONS):
+                pdf_inputs.append(raw)
+                continue
+            # PNG/WEBP 等は JPEG にエンコードし直す（透過は白背景で合成）
+            with Image.open(io.BytesIO(raw)) as img:
+                if img.mode in ("RGBA", "LA"):
+                    background = Image.new("RGB", img.size, (255, 255, 255))
+                    background.paste(img, mask=img.split()[-1])
+                    converted = background
+                elif img.mode != "RGB":
+                    converted = img.convert("RGB")
+                else:
+                    converted = img
+                buf = io.BytesIO()
+                converted.save(buf, format="JPEG", quality=90)
+                pdf_inputs.append(buf.getvalue())
+        return pdf_inputs
 
 
 class ImageConvertView(APIView):

--- a/django_api/pyproject.toml
+++ b/django_api/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "djangorestframework>=3.16.1",
     "drf-spectacular>=0.28.0",
     "gunicorn>=23.0.0",
+    "img2pdf>=0.5.0",
     "langchain-core>=0.3.0",
     "langchain-openai>=0.3.0",
     "langfuse>=3.0.0,<4.0.0",

--- a/django_api/tests/features/media/test_views.py
+++ b/django_api/tests/features/media/test_views.py
@@ -325,18 +325,18 @@ class TestZipToPdfView:
         assert ".." not in disposition
         assert "/" not in disposition.split("filename=", 1)[1].split(";", 1)[0]
 
-    def test_zip_to_pdf_returns_413_when_total_megapixels_exceed_limit(
+    def test_zip_to_pdf_returns_413_when_single_image_exceeds_megapixel_limit(
         self, authenticated_client, create_zip_file, monkeypatch
     ):
-        """ZIP内画像の合計メガピクセル数がハードリミットを超える場合は413を返す。
+        """ZIP内に1枚あたりの上限を超える画像が含まれる場合は413を返す。
 
-        本番のメモリ枠（512MiB）を守るため、展開後の概算メモリを事前に算出し
-        危険なリクエストは即座に拒否する。
+        合計ではなく単一画像のメガピクセルでガードする（img2pdf は JPEG を
+        そのまま埋め込むため、合計で縛ると本来通せる多枚数スキャンを弾く）。
         """
         from features.media.views import ZipToPdfView
 
-        # 上限を 0.5 メガピクセルまで一時的に下げる
-        monkeypatch.setattr(ZipToPdfView, "MAX_TOTAL_MEGAPIXELS", 0.5)
+        # 1 枚あたりの上限を 0.5 メガピクセルまで一時的に下げる
+        monkeypatch.setattr(ZipToPdfView, "MAX_PER_IMAGE_MEGAPIXELS", 0.5)
 
         # 1000x1000 = 1.0 メガピクセル → 上限超過
         zip_file = create_zip_file(
@@ -356,12 +356,43 @@ class TestZipToPdfView:
 
         assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
         assert "error" in response.data
-        # 原因が利用者に伝わるメッセージであること
+        # 原因が利用者に伝わるメッセージであり、対象ファイル名も含むこと
+        assert "big.jpg" in response.data["error"]
         assert (
             "解像度" in response.data["error"]
             or "メガピクセル" in response.data["error"]
-            or "サイズ" in response.data["error"]
         )
+
+    def test_zip_to_pdf_passes_when_total_megapixels_high_but_each_image_small(
+        self, authenticated_client, create_zip_file, monkeypatch
+    ):
+        """合計メガピクセル数が大きくても、1枚ずつが上限以下なら通ること。
+
+        漫画スキャン等の「数十枚×中解像度」ユースケースを誤って弾かないことを保証する。
+        """
+        from features.media.views import ZipToPdfView
+
+        # 1 枚あたり 1.5MP まで許容（500x500 = 0.25MP * 6 枚 = 1.5MP 合計）
+        monkeypatch.setattr(ZipToPdfView, "MAX_PER_IMAGE_MEGAPIXELS", 1.5)
+
+        zip_file = create_zip_file(
+            [
+                {
+                    "name": f"page_{i:02d}.jpg",
+                    "format": "JPEG",
+                    "color": "red",
+                    "size": (500, 500),
+                }
+                for i in range(6)
+            ]
+        )
+        payload = {"file": zip_file}
+        response = authenticated_client.post(
+            "/media/zip-to-pdf/", payload, format="multipart"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response["Content-Type"] == "application/pdf"
 
     def test_zip_to_pdf_returns_503_on_memory_error(
         self, authenticated_client, create_zip_file, mocker
@@ -372,9 +403,7 @@ class TestZipToPdfView:
         本番OOMを切り分けできなかった。
         """
         # img2pdf 経由の変換中に MemoryError を発生させる
-        mocker.patch(
-            "features.media.views.img2pdf.convert", side_effect=MemoryError()
-        )
+        mocker.patch("features.media.views.img2pdf.convert", side_effect=MemoryError())
 
         zip_file = create_zip_file(
             [{"name": "image.jpg", "format": "JPEG", "color": "red"}]

--- a/django_api/tests/features/media/test_views.py
+++ b/django_api/tests/features/media/test_views.py
@@ -60,6 +60,7 @@ def create_zip_file(create_test_image):
         Args:
             files: ファイルのリスト [{'name': 'file.jpg', 'format': 'JPEG', 'color': 'red'}, ...]
                    または [{'name': 'file.txt', 'content': b'text content'}, ...]
+                   画像エントリは任意で size=(width, height) を指定できる。
             zip_name: アップロードファイル名（デフォルト: "test.zip"）
 
         Returns:
@@ -72,6 +73,7 @@ def create_zip_file(create_test_image):
                     # 画像ファイル
                     content = create_test_image(
                         format=file_info.get("format", "JPEG"),
+                        size=file_info.get("size", (100, 100)),
                         color=file_info.get("color", "red"),
                     )
                 else:
@@ -322,6 +324,69 @@ class TestZipToPdfView:
         # パス成分が漏れていないこと
         assert ".." not in disposition
         assert "/" not in disposition.split("filename=", 1)[1].split(";", 1)[0]
+
+    def test_zip_to_pdf_returns_413_when_total_megapixels_exceed_limit(
+        self, authenticated_client, create_zip_file, monkeypatch
+    ):
+        """ZIP内画像の合計メガピクセル数がハードリミットを超える場合は413を返す。
+
+        本番のメモリ枠（512MiB）を守るため、展開後の概算メモリを事前に算出し
+        危険なリクエストは即座に拒否する。
+        """
+        from features.media.views import ZipToPdfView
+
+        # 上限を 0.5 メガピクセルまで一時的に下げる
+        monkeypatch.setattr(ZipToPdfView, "MAX_TOTAL_MEGAPIXELS", 0.5)
+
+        # 1000x1000 = 1.0 メガピクセル → 上限超過
+        zip_file = create_zip_file(
+            [
+                {
+                    "name": "big.jpg",
+                    "format": "JPEG",
+                    "color": "red",
+                    "size": (1000, 1000),
+                }
+            ]
+        )
+        payload = {"file": zip_file}
+        response = authenticated_client.post(
+            "/media/zip-to-pdf/", payload, format="multipart"
+        )
+
+        assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+        assert "error" in response.data
+        # 原因が利用者に伝わるメッセージであること
+        assert (
+            "解像度" in response.data["error"]
+            or "メガピクセル" in response.data["error"]
+            or "サイズ" in response.data["error"]
+        )
+
+    def test_zip_to_pdf_returns_503_on_memory_error(
+        self, authenticated_client, create_zip_file, mocker
+    ):
+        """変換中にMemoryErrorが発生した場合は503と原因が分かるメッセージを返す。
+
+        従来は汎用エラー「画像の処理中にエラーが発生しました」に潰れて
+        本番OOMを切り分けできなかった。
+        """
+        # img2pdf 経由の変換中に MemoryError を発生させる
+        mocker.patch(
+            "features.media.views.img2pdf.convert", side_effect=MemoryError()
+        )
+
+        zip_file = create_zip_file(
+            [{"name": "image.jpg", "format": "JPEG", "color": "red"}]
+        )
+        payload = {"file": zip_file}
+        response = authenticated_client.post(
+            "/media/zip-to-pdf/", payload, format="multipart"
+        )
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert "error" in response.data
+        assert "メモリ" in response.data["error"]
 
 
 @pytest.mark.api

--- a/django_api/uv.lock
+++ b/django_api/uv.lock
@@ -373,6 +373,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -406,6 +418,7 @@ dependencies = [
     { name = "djangorestframework" },
     { name = "drf-spectacular" },
     { name = "gunicorn" },
+    { name = "img2pdf" },
     { name = "langchain-core" },
     { name = "langchain-openai" },
     { name = "langfuse" },
@@ -443,6 +456,7 @@ requires-dist = [
     { name = "djangorestframework", specifier = ">=3.16.1" },
     { name = "drf-spectacular", specifier = ">=0.28.0" },
     { name = "gunicorn", specifier = ">=23.0.0" },
+    { name = "img2pdf", specifier = ">=0.5.0" },
     { name = "langchain-core", specifier = ">=0.3.0" },
     { name = "langchain-openai", specifier = ">=0.3.0" },
     { name = "langfuse", specifier = ">=3.0.0,<4.0.0" },
@@ -631,6 +645,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "img2pdf"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pikepdf" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/97/ca44c467131b93fda82d2a2f21b738c8bcf63b5259e3b8250e928b8dd52a/img2pdf-0.6.3.tar.gz", hash = "sha256:219518020f5bd242bdc46493941ea3f756f664c2e86f2454721e74353f58cd95", size = 120350, upload-time = "2025-11-05T20:51:57.558Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/dc/91e3a4a11c25ae183bd5a71b84ecb298db76405ff70013f76b10877bdfe3/img2pdf-0.6.3-py3-none-any.whl", hash = "sha256:44d12d235752edd17c43c04ff39952cdc5dd4c6aba90569c4902bd445085266b", size = 49701, upload-time = "2025-11-05T20:51:55.469Z" },
 ]
 
 [[package]]
@@ -912,6 +939,68 @@ wheels = [
 ]
 
 [[package]]
+name = "lxml"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006, upload-time = "2026-04-18T04:32:51.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/03/69347590f1cf4a6d5a4944bb6099e6d37f334784f16062234e1f892fdb1d/lxml-6.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0092f2b107b69601adf562a57c956fbb596e05e3e6651cabd3054113b007e45", size = 8559689, upload-time = "2026-04-18T04:31:57.785Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/58/25e00bb40b185c974cfe156c110474d9a8a8390d5f7c92a4e328189bb60e/lxml-6.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fc7140d7a7386e6b545d41b7358f4d02b656d4053f5fa6859f92f4b9c2572c4d", size = 4617892, upload-time = "2026-04-18T04:32:01.78Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/54/92ad98a94ac318dc4f97aaac22ff8d1b94212b2ae8af5b6e9b354bf825f7/lxml-6.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:419c58fc92cc3a2c3fa5f78c63dbf5da70c1fa9c1b25f25727ecee89a96c7de2", size = 4923489, upload-time = "2026-04-18T04:33:31.401Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3b/a20aecfab42bdf4f9b390590d345857ad3ffd7c51988d1c89c53a0c73faf/lxml-6.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37fabd1452852636cf38ecdcc9dd5ca4bba7a35d6c53fa09725deeb894a87491", size = 5082162, upload-time = "2026-04-18T04:33:34.262Z" },
+    { url = "https://files.pythonhosted.org/packages/45/26/2cdb3d281ac1bd175603e290cbe4bad6eff127c0f8de90bafd6f8548f0fd/lxml-6.1.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2853c8b2170cc6cd54a6b4d50d2c1a8a7aeca201f23804b4898525c7a152cfc", size = 4993247, upload-time = "2026-04-18T04:33:36.674Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/05/d735aef963740022a08185c84821f689fc903acb3d50326e6b1e9886cc22/lxml-6.1.0-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e369cbd690e788c8d15e56222d91a09c6a417f49cbc543040cba0fe2e25a79e", size = 5613042, upload-time = "2026-04-18T04:33:39.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/ead7c10efff731738c72e59ed6eb5791854879fbed7ae98781a12006263a/lxml-6.1.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69aa6805905807186eb00e66c6d97a935c928275182eb02ee40ba00da9623b2", size = 5228304, upload-time = "2026-04-18T04:33:41.647Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/10/e9842d2ec322ea65f0a7270aa0315a53abed06058b88ef1b027f620e7a5f/lxml-6.1.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:4bd1bdb8a9e0e2dd229de19b5f8aebac80e916921b4b2c6ef8a52bc131d0c1f9", size = 5341578, upload-time = "2026-04-18T04:33:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/89/54/40d9403d7c2775fa7301d3ddd3464689bfe9ba71acc17dfff777071b4fdc/lxml-6.1.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:cbd7b79cdcb4986ad78a2662625882747f09db5e4cd7b2ae178a88c9c51b3dfe", size = 4700209, upload-time = "2026-04-18T04:33:47.552Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/bbdcc2cf45dfc7dfffef4fd97e5c47b15919b6a365247d95d6f684ef5e82/lxml-6.1.0-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:43e4d297f11080ec9d64a4b1ad7ac02b4484c9f0e2179d9c4ef78e886e747b88", size = 5232365, upload-time = "2026-04-18T04:33:50.249Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/b06875665e53aaba7127611a7bed3b7b9658e20b22bc2dd217a0b7ab0091/lxml-6.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cc16682cc987a3da00aa56a3aa3075b08edb10d9b1e476938cfdbee8f3b67181", size = 5043654, upload-time = "2026-04-18T04:33:52.71Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9c/e71a069d09641c1a7abeb30e693f828c7c90a41cbe3d650b2d734d876f85/lxml-6.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d6d8efe71429635f0559579092bb5e60560d7b9115ee38c4adbea35632e7fa24", size = 4769326, upload-time = "2026-04-18T04:33:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/06/7a9cd84b3d4ed79adf35f874750abb697dec0b4a81a836037b36e47c091a/lxml-6.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e39ab3a28af7784e206d8606ec0e4bcad0190f63a492bca95e94e5a4aef7f6e", size = 5635879, upload-time = "2026-04-18T04:33:58.509Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f0/9d57916befc1e54c451712c7ee48e9e74e80ae4d03bdce49914e0aee42cd/lxml-6.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9eb667bf50856c4a58145f8ca2d5e5be160191e79eb9e30855a476191b3c3495", size = 5224048, upload-time = "2026-04-18T04:34:00.943Z" },
+    { url = "https://files.pythonhosted.org/packages/99/75/90c4eefda0c08c92221fe0753db2d6699a4c628f76ff4465ec20dea84cc1/lxml-6.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f4a77d6f7edf9230cee3e1f7f6764722a41604ee5681844f18db9a81ea0ec33", size = 5250241, upload-time = "2026-04-18T04:34:03.365Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/73/16596f7e4e38fa33084b9ccbccc22a15f82a290a055126f2c1541236d2ff/lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62", size = 3596938, upload-time = "2026-04-18T04:31:56.206Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/63/981401c5680c1eb30893f00a19641ac80db5d1e7086c62cb4b13ed813038/lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16", size = 3995728, upload-time = "2026-04-18T04:31:58.763Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/c358a38ac3e541d16a1b527e4e9cb78c0419b0506a070ace11777e5e8404/lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d", size = 3658372, upload-time = "2026-04-18T04:32:03.629Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/cee4cf203ef0bab5c52afc118da61d6b460c928f2893d40023cfa27e0b80/lxml-6.1.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ab863fd37458fed6456525f297d21239d987800c46e67da5ef04fc6b3dd93ac8", size = 8576713, upload-time = "2026-04-18T04:32:06.831Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a7/eda05babeb7e046839204eaf254cd4d7c9130ce2bbf0d9e90ea41af5654d/lxml-6.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6fd8b1df8254ff4fd93fd31da1fc15770bde23ac045be9bb1f87425702f61cc9", size = 4623874, upload-time = "2026-04-18T04:32:10.755Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e9/db5846de9b436b91890a62f29d80cd849ea17948a49bf532d5278ee69a9e/lxml-6.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:47024feaae386a92a146af0d2aeed65229bf6fff738e6a11dda6b0015fb8fd03", size = 4949535, upload-time = "2026-04-18T04:34:06.657Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ba/0d3593373dcae1d68f40dc3c41a5a92f2544e68115eb2f62319a4c2a6500/lxml-6.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3f00972f84450204cd5d93a5395965e348956aaceaadec693a22ec743f8ae3eb", size = 5086881, upload-time = "2026-04-18T04:34:09.556Z" },
+    { url = "https://files.pythonhosted.org/packages/43/76/759a7484539ad1af0d125a9afe9c3fb5f82a8779fd1f5f56319d9e4ea2fd/lxml-6.1.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97faa0860e13b05b15a51fb4986421ef7a30f0b3334061c416e0981e9450ca4c", size = 5031305, upload-time = "2026-04-18T04:34:12.336Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/c1f0daf981a11e47636126901fd4ab82429e18c57aeb0fc3ad2940b42d8b/lxml-6.1.0-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:972a6451204798675407beaad97b868d0c733d9a74dafefc63120b81b8c2de28", size = 5647522, upload-time = "2026-04-18T04:34:14.89Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e6/1f533dcd205275363d9ba3511bcec52fa2df86abf8abe6a5f2c599f0dc31/lxml-6.1.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fe022f20bc4569ec66b63b3fb275a3d628d9d32da6326b2982584104db6d3086", size = 5239310, upload-time = "2026-04-18T04:34:17.652Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/8c/4175fb709c78a6e315ed814ed33be3defd8b8721067e70419a6cf6f971da/lxml-6.1.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:75c4c7c619a744f972f4451bf5adf6d0fb00992a1ffc9fd78e13b0bc817cc99f", size = 5350799, upload-time = "2026-04-18T04:34:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/77/6ffdebc5994975f0dde4acb59761902bd9d9bb84422b9a0bd239a7da9ca8/lxml-6.1.0-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3648f20d25102a22b6061c688beb3a805099ea4beb0a01ce62975d926944d292", size = 4697693, upload-time = "2026-04-18T04:34:23.541Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f1/565f36bd5c73294602d48e04d23f81ff4c8736be6ba5e1d1ec670ac9be80/lxml-6.1.0-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:77b9f99b17cbf14026d1e618035077060fc7195dd940d025149f3e2e830fbfcb", size = 5250708, upload-time = "2026-04-18T04:34:26.001Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/11/a68ab9dd18c5c499404deb4005f4bc4e0e88e5b72cd755ad96efec81d18d/lxml-6.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32662519149fd7a9db354175aa5e417d83485a8039b8aaa62f873ceee7ea4cad", size = 5084737, upload-time = "2026-04-18T04:34:28.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/78/e8f41e2c74f4af564e6a0348aea69fb6daaefa64bc071ef469823d22cc18/lxml-6.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:73d658216fc173cf2c939e90e07b941c5e12736b0bf6a99e7af95459cfe8eabb", size = 4737817, upload-time = "2026-04-18T04:34:30.784Z" },
+    { url = "https://files.pythonhosted.org/packages/06/2d/aa4e117aa2ce2f3b35d9ff246be74a2f8e853baba5d2a92c64744474603a/lxml-6.1.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ac4db068889f8772a4a698c5980ec302771bb545e10c4b095d4c8be26749616f", size = 5670753, upload-time = "2026-04-18T04:34:33.675Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f5/dd745d50c0409031dbfcc4881740542a01e54d6f0110bd420fa7782110b8/lxml-6.1.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:45e9dfbd1b661eb64ba0d4dbe762bd210c42d86dd1e5bd2bdf89d634231beb43", size = 5238071, upload-time = "2026-04-18T04:34:36.12Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/74/ad424f36d0340a904665867dab310a3f1f4c96ff4039698de83b77f44c1f/lxml-6.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:89e8d73d09ac696a5ba42ec69787913d53284f12092f651506779314f10ba585", size = 5264319, upload-time = "2026-04-18T04:34:39.035Z" },
+    { url = "https://files.pythonhosted.org/packages/53/36/a15d8b3514ec889bfd6aa3609107fcb6c9189f8dc347f1c0b81eded8d87c/lxml-6.1.0-cp314-cp314-win32.whl", hash = "sha256:ebe33f4ec1b2de38ceb225a1749a2965855bffeef435ba93cd2d5d540783bf2f", size = 3657139, upload-time = "2026-04-18T04:32:20.006Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a4/263ebb0710851a3c6c937180a9a86df1206fdfe53cc43005aa2237fd7736/lxml-6.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:398443df51c538bd578529aa7e5f7afc6c292644174b47961f3bf87fe5741120", size = 4064195, upload-time = "2026-04-18T04:32:23.876Z" },
+    { url = "https://files.pythonhosted.org/packages/80/68/2000f29d323b6c286de077ad20b429fc52272e44eae6d295467043e56012/lxml-6.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:8c8984e1d8c4b3949e419158fda14d921ff703a9ed8a47236c6eb7a2b6cb4946", size = 3741870, upload-time = "2026-04-18T04:32:27.922Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e9/21383c7c8d43799f0da90224c0d7c921870d476ec9b3e01e1b2c0b8237c5/lxml-6.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1081dd10bc6fa437db2500e13993abf7cc30716d0a2f40e65abb935f02ec559c", size = 8827548, upload-time = "2026-04-18T04:32:15.094Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/01/c6bc11cd587030dd4f719f65c5657960649fe3e19196c844c75bf32cd0d6/lxml-6.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dabecc48db5f42ba348d1f5d5afdc54c6c4cc758e676926c7cd327045749517d", size = 4735866, upload-time = "2026-04-18T04:32:18.924Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/01/757132fff5f4acf25463b5298f1a46099f3a94480b806547b29ce5e385de/lxml-6.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e3dd5fe19c9e0ac818a9c7f132a5e43c1339ec1cbbfecb1a938bd3a47875b7c9", size = 4969476, upload-time = "2026-04-18T04:34:41.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/fb/1bc8b9d27ed64be7c8903db6c89e74dc8c2cd9ec630a7462e4654316dc5b/lxml-6.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9e7b0a4ca6dcc007a4cef00a761bba2dea959de4bd2df98f926b33c92ca5dfb9", size = 5103719, upload-time = "2026-04-18T04:34:44.797Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e7/5bf82fa28133536a54601aae633b14988e89ed61d4c1eb6b899b023233aa/lxml-6.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d27bbe326c6b539c64b42638b18bc6003a8d88f76213a97ac9ed4f885efeab7", size = 5027890, upload-time = "2026-04-18T04:34:47.634Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/20/e048db5d4b4ea0366648aa595f26bb764b2670903fc585b87436d0a5032c/lxml-6.1.0-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4e425db0c5445ef0ad56b0eec54f89b88b2d884656e536a90b2f52aecb4ca86", size = 5596008, upload-time = "2026-04-18T04:34:51.503Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/c2/d10807bc8da4824b39e5bd01b5d05c077b6fd01bd91584167edf6b269d22/lxml-6.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b89b098105b8599dc57adac95d1813409ac476d3c948a498775d3d0c6124bfb", size = 5224451, upload-time = "2026-04-18T04:34:54.263Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/15/2ebea45bea427e7f0057e9ce7b2d62c5aba20c6b001cca89ed0aadb3ad41/lxml-6.1.0-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:c4a699432846df86cc3de502ee85f445ebad748a1c6021d445f3e514d2cd4b1c", size = 5312135, upload-time = "2026-04-18T04:34:56.818Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e2/87eeae151b0be2a308d49a7ec444ff3eb192b14251e62addb29d0bf3778f/lxml-6.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:30e7b2ed63b6c8e97cca8af048589a788ab5c9c905f36d9cf1c2bb549f450d2f", size = 4639126, upload-time = "2026-04-18T04:34:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/51/8a3f6a20902ad604dd746ec7b4000311b240d389dac5e9d95adefd349e0c/lxml-6.1.0-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:022981127642fe19866d2907d76241bb07ed21749601f727d5d5dd1ce5d1b773", size = 5232579, upload-time = "2026-04-18T04:35:02.658Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d2/650d619bdbe048d2c3f2c31edb00e35670a5e2d65b4fe3b61bce37b19121/lxml-6.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:23cad0cc86046d4222f7f418910e46b89971c5a45d3c8abfad0f64b7b05e4a9b", size = 5084206, upload-time = "2026-04-18T04:35:05.175Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8a/672ca1a3cbeabd1f511ca275a916c0514b747f4b85bdaae103b8fa92f307/lxml-6.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:21c3302068f50d1e8728c67c87ba92aa87043abee517aa2576cca1855326b405", size = 4758906, upload-time = "2026-04-18T04:35:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f1/ef4b691da85c916cb2feb1eec7414f678162798ac85e042fa164419ac05c/lxml-6.1.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:be10838781cb3be19251e276910cd508fe127e27c3242e50521521a0f3781690", size = 5620553, upload-time = "2026-04-18T04:35:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/59/17/94e81def74107809755ac2782fdad4404420f1c92ca83433d117a6d5acf0/lxml-6.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2173a7bffe97667bbf0767f8a99e587740a8c56fdf3befac4b09cb29a80276fd", size = 5229458, upload-time = "2026-04-18T04:35:14.254Z" },
+    { url = "https://files.pythonhosted.org/packages/21/55/c4be91b0f830a871fc1b0d730943d56013b683d4671d5198260e2eae722b/lxml-6.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c6854e9cf99c84beb004eecd7d3a3868ef1109bf2b1df92d7bc11e96a36c2180", size = 5247861, upload-time = "2026-04-18T04:35:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ca/77123e4d77df3cb1e968ade7b1f808f5d3a5c1c96b18a33895397de292c1/lxml-6.1.0-cp314-cp314t-win32.whl", hash = "sha256:00750d63ef0031a05331b9223463b1c7c02b9004cef2346a5b2877f0f9494dd2", size = 3897377, upload-time = "2026-04-18T04:32:07.656Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ce/3554833989d074267c063209bae8b09815e5656456a2d332b947806b05ff/lxml-6.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:80410c3a7e3c617af04de17caa9f9f20adaa817093293d69eae7d7d0522836f5", size = 4392701, upload-time = "2026-04-18T04:32:12.113Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a0/9b916c68c0e57752c07f8f64b30138d9d4059dbeb27b90274dedbea128ff/lxml-6.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:26dd9f57ee3bd41e7d35b4c98a2ffd89ed11591649f421f0ec19f67d50ec67ac", size = 3817120, upload-time = "2026-04-18T04:32:15.803Z" },
+]
+
+[[package]]
 name = "msal"
 version = "1.34.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1163,6 +1252,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/6c/6d8b4b03b958c02fa8687ec6063c49d952a189f8c91ebbe51e877dfab8f7/pgvector-0.4.2.tar.gz", hash = "sha256:322cac0c1dc5d41c9ecf782bd9991b7966685dee3a00bc873631391ed949513a", size = 31354, upload-time = "2025-12-05T01:07:17.87Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/26/6cee8a1ce8c43625ec561aff19df07f9776b7525d9002c86bceb3e0ac970/pgvector-0.4.2-py3-none-any.whl", hash = "sha256:549d45f7a18593783d5eec609ea1684a724ba8405c4cb182a0b2b08aeff04e08", size = 27441, upload-time = "2025-12-05T01:07:16.536Z" },
+]
+
+[[package]]
+name = "pikepdf"
+version = "10.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "lxml" },
+    { name = "packaging" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/66/32a45480d84cb239c7ad31209c956496fe5b20f6fb163d794db4c79f840c/pikepdf-10.5.1.tar.gz", hash = "sha256:ffa6c7d0b77deb3af9735e0b0cae177c897431e10d342bb171b62e5527a622b7", size = 4582470, upload-time = "2026-03-18T07:56:00.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/d4/eb00bb96b383a1dd3151d347a6339408af642d75ed998f8ac7368ddf5bcd/pikepdf-10.5.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:0b30d192baf0132e6d945e8b2200288bd32f2b0ec2357b1fe414ef595531b181", size = 4772545, upload-time = "2026-03-18T07:55:33.251Z" },
+    { url = "https://files.pythonhosted.org/packages/42/6f/f25b9e66afd647cd090d0e62a5287135ec0ae4971b2f1601a1e3dad96fa9/pikepdf-10.5.1-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:d59a710ba6fc5a5220ac59dba4bd43612663a2fde33973a616843bc79eaf0fac", size = 5088950, upload-time = "2026-03-18T07:55:35.222Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9e/f2781afe47f149f88b1c2a3e72a0f2501fcc104c23bffb2e68c89ec81ea7/pikepdf-10.5.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f245df7aeb1a69c166e923ceae9bf47c895a06286dcb94a92225f1b10156e6f", size = 2490804, upload-time = "2026-03-18T07:55:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/77/f87710f01d74dfe8d3713cfe682b350c77aa7a5443552fffceb7b3b40543/pikepdf-10.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e1cdfdeec93a6eca49e6ce592269fd78007d13440719d6f95f3a5a33e609d9f", size = 2734878, upload-time = "2026-03-18T07:55:39.061Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/b1/b350dc5cf82de45c0c1c79fd01384b0af07e3ba82da77e276bc98ca00489/pikepdf-10.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b21b093335069d79eecf8639b150e6100043b1275ffdeb00501640d2bcbdf760", size = 3699375, upload-time = "2026-03-18T07:55:40.984Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/5e/f7c7473c36687d453bede6afb0a4d8fb0ebb2e846f35219db12542889df1/pikepdf-10.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:89cc87b440f663f1e4f51670930f0aa310cec30cc02d9a1c36a61432be9380fd", size = 3908458, upload-time = "2026-03-18T07:55:43.051Z" },
+    { url = "https://files.pythonhosted.org/packages/38/4a/b2949669f3eaae08cc32d21b13f505ebbcabb0d7dd8808fdf743a9eb69ae/pikepdf-10.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:d10f915c80881be4802204a54ba3ce5ee9e13dd59aa6fbe4cb95230039defa86", size = 3812315, upload-time = "2026-03-18T07:55:44.829Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/48/b513468b4a5c7d4d9007c2c9b59686d15cca88c339225e4f2069c15799f9/pikepdf-10.5.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:ac7a96d6e4a23cd2dfc07f2cec9f55b000fcd4be4be888dbbe5a767dcd4c409e", size = 4770764, upload-time = "2026-03-18T07:55:46.597Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/42/da2abc72d0d04b48158b6bccad6e31dfd2cef63f501cdb6192af100d7545/pikepdf-10.5.1-cp314-cp314-macosx_15_0_x86_64.whl", hash = "sha256:1b81fd3f3de40ec4ad87fe9337d91e5f1301d4c4450ff02f4aa581c76609a3b7", size = 5089799, upload-time = "2026-03-18T07:55:48.45Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/47/19731ef57be6007fb5007438618d6803d7abb4adaa095e55a8e7bd5cfa25/pikepdf-10.5.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:781ee394f38ebdf412dc674a1e3333a844dbab673d4d8db04050055062b8fa8d", size = 2493677, upload-time = "2026-03-18T07:55:50.219Z" },
+    { url = "https://files.pythonhosted.org/packages/25/87/3e115b7a47c3a5bb3a58a7ba51de20d4964393735fab0085fc94a979113b/pikepdf-10.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17e6a136b870424e66167035406662842783049ee14262f49ed2572caa584475", size = 2736452, upload-time = "2026-03-18T07:55:52.266Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/2b/f30006c28b58a12116561fe4fe62c9cd630e97a88de799c27a3073c6bb55/pikepdf-10.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c9ae38d8dd7acf1b4c9bcd9a38fb75735bc62049c34634b1899e47068b314c5f", size = 3702958, upload-time = "2026-03-18T07:55:54.294Z" },
+    { url = "https://files.pythonhosted.org/packages/83/47/d467f13394c3be1c57b0fbc4264a8f0d1f6ae42ae61299c4695a89b2d983/pikepdf-10.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:013411404eb129b8d0cd565ce09c4f99254b9837a8e66f90d150b7c1f23a7124", size = 3910716, upload-time = "2026-03-18T07:55:56.233Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/b5/7753d726905f217b78e677fee82e877a6880bc326db3a13c1934884ed54b/pikepdf-10.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:70d1b5ae2e61ab5a08e2c978d18208766d5aa0747a2181c95d6e3acaa114f278", size = 3923717, upload-time = "2026-03-18T07:55:58.16Z" },
 ]
 
 [[package]]

--- a/frontend/src/features/media/useMedia.ts
+++ b/frontend/src/features/media/useMedia.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
-import { convertImage, zipToPdf } from '@/lib/api/media';
+import {
+    convertImage,
+    extractApiErrorMessage,
+    zipToPdf,
+} from '@/lib/api/media';
 import type { OutputFormat } from '@/types/media';
 
 interface MediaResult {
@@ -35,9 +39,13 @@ export function useMedia() {
                 previousUrlRef.current = url;
                 setResult({ blob: res.blob, filename: res.filename, url });
                 toast.success('画像を変換しました');
-            } catch {
-                setError('画像変換に失敗しました');
-                toast.error('画像変換に失敗しました');
+            } catch (e) {
+                const msg = await extractApiErrorMessage(
+                    e,
+                    '画像変換に失敗しました',
+                );
+                setError(msg);
+                toast.error(msg);
             } finally {
                 setIsLoading(false);
             }
@@ -60,9 +68,13 @@ export function useMedia() {
             previousUrlRef.current = url;
             setResult({ blob: res.blob, filename: res.filename, url });
             toast.success('PDFに変換しました');
-        } catch {
-            setError('ZIP→PDF変換に失敗しました');
-            toast.error('ZIP→PDF変換に失敗しました');
+        } catch (e) {
+            const msg = await extractApiErrorMessage(
+                e,
+                'ZIP→PDF変換に失敗しました',
+            );
+            setError(msg);
+            toast.error(msg);
         } finally {
             setIsLoading(false);
         }

--- a/frontend/src/lib/api/media.ts
+++ b/frontend/src/lib/api/media.ts
@@ -29,6 +29,12 @@ export async function extractApiErrorMessage(
     return fallback;
 }
 
+function sanitizeDownloadFilename(name: string): string {
+    // 改行・パス区切り・制御文字を除去（不正サーバー / MITM の改ざん対策の2段防御）
+    // eslint-disable-next-line no-control-regex -- 制御文字の除去自体が目的
+    return name.replace(/[\r\n\\/\x00-\x1f\x7f]/g, '_');
+}
+
 function extractFilename(
     contentDisposition: string | null,
     fallback: string,
@@ -40,13 +46,15 @@ function extractFilename(
     );
     if (utf8Match) {
         try {
-            return decodeURIComponent(utf8Match[1].trim());
+            return sanitizeDownloadFilename(
+                decodeURIComponent(utf8Match[1].trim()),
+            );
         } catch {
             // 不正なパーセントエンコードの場合は ASCII フォールバックへ
         }
     }
     const match = contentDisposition.match(/filename="?([^";\s]+)"?/);
-    return match ? match[1] : fallback;
+    return match ? sanitizeDownloadFilename(match[1]) : fallback;
 }
 
 export async function convertImage(

--- a/frontend/src/lib/api/media.ts
+++ b/frontend/src/lib/api/media.ts
@@ -1,9 +1,32 @@
+import { HTTPError } from 'ky';
 import { apiClient } from '@/lib/api-client';
 import type { ConvertImageParams } from '@/types/media';
 
 interface MediaResult {
     readonly blob: Blob;
     readonly filename: string;
+}
+
+export async function extractApiErrorMessage(
+    error: unknown,
+    fallback: string,
+): Promise<string> {
+    if (!(error instanceof HTTPError)) return fallback;
+    try {
+        const body = (await error.response.json()) as unknown;
+        if (
+            body !== null &&
+            typeof body === 'object' &&
+            'error' in body &&
+            typeof (body as { error: unknown }).error === 'string'
+        ) {
+            const message = (body as { error: string }).error.trim();
+            if (message !== '') return message;
+        }
+    } catch {
+        // JSON でないレスポンスや response body を二重消費した場合は fallback
+    }
+    return fallback;
 }
 
 function extractFilename(

--- a/frontend/tests/lib/api/media.test.ts
+++ b/frontend/tests/lib/api/media.test.ts
@@ -8,7 +8,7 @@ import {
     expect,
     it,
 } from 'vitest';
-import { convertImage, zipToPdf } from '@/lib/api/media';
+import { convertImage, extractApiErrorMessage, zipToPdf } from '@/lib/api/media';
 
 const server = setupServer(
     http.post('*/api/media/convert-image/', () => {
@@ -102,5 +102,60 @@ describe('Media API', () => {
         const result = await zipToPdf(file);
 
         expect(result.filename).toBe('あいうえお.pdf');
+    });
+
+    it('extractApiErrorMessage は ky の HTTPError から error フィールドを取り出す', async () => {
+        server.use(
+            http.post('*/api/media/zip-to-pdf/', () => {
+                return HttpResponse.json(
+                    {
+                        error: 'サーバーのメモリが不足しました。画像の枚数を減らすか、解像度を下げて再試行してください',
+                    },
+                    { status: 503 },
+                );
+            }),
+        );
+
+        const file = new File(['test'], 'big.zip', {
+            type: 'application/zip',
+        });
+        let caught: unknown = null;
+        try {
+            await zipToPdf(file);
+        } catch (e) {
+            caught = e;
+        }
+
+        const msg = await extractApiErrorMessage(caught, 'fallback');
+        expect(msg).toContain('メモリ');
+    });
+
+    it('extractApiErrorMessage はJSONでないボディの場合はfallbackを返す', async () => {
+        server.use(
+            http.post('*/api/media/zip-to-pdf/', () => {
+                return new HttpResponse('not json', { status: 500 });
+            }),
+        );
+
+        const file = new File(['test'], 't.zip', {
+            type: 'application/zip',
+        });
+        let caught: unknown = null;
+        try {
+            await zipToPdf(file);
+        } catch (e) {
+            caught = e;
+        }
+
+        const msg = await extractApiErrorMessage(caught, 'fallback文言');
+        expect(msg).toBe('fallback文言');
+    });
+
+    it('extractApiErrorMessage は HTTPError でない例外の場合は fallback を返す', async () => {
+        const msg = await extractApiErrorMessage(
+            new Error('network down'),
+            'fallback文言',
+        );
+        expect(msg).toBe('fallback文言');
     });
 });

--- a/frontend/tests/lib/api/media.test.ts
+++ b/frontend/tests/lib/api/media.test.ts
@@ -158,4 +158,29 @@ describe('Media API', () => {
         );
         expect(msg).toBe('fallback文言');
     });
+
+    it('改行や パス区切りを含むファイル名は _ にサニタイズされる', async () => {
+        // RFC 5987 経路: \r\n / \\ がサーバー or MITM で混入したケース
+        server.use(
+            http.post('*/api/media/zip-to-pdf/', () => {
+                return new HttpResponse('fake-pdf-data', {
+                    status: 200,
+                    headers: {
+                        'Content-Type': 'application/pdf',
+                        'Content-Disposition':
+                            "attachment; filename=\"x.pdf\"; filename*=UTF-8''bad%0D%0Aname%2F%5C.pdf",
+                    },
+                });
+            }),
+        );
+
+        const file = new File(['test'], 'in.zip', {
+            type: 'application/zip',
+        });
+        const result = await zipToPdf(file);
+
+        // 改行・/ ・\ は すべて _ に置換されること
+        expect(result.filename).toBe('bad__name__.pdf');
+        expect(result.filename).not.toMatch(/[\r\n\\/]/);
+    });
 });


### PR DESCRIPTION
## Summary

`develop` の最新を `main` にリリース。本番 `django-api` (mem_limit 512m) で発生していた ZIP→PDF 変換の隠れ OOM を解消。

## 取り込まれる変更（PR #230）

- `img2pdf` ベースのストリーミング書き出しに変更（PIL Image を全枚数同時保持しなくなる）
- 例外を 503 / 413 / 400 に細分化（`MemoryError` / `Image.DecompressionBombError` / その他）
- `MAX_PER_IMAGE_MEGAPIXELS = 100` の事前バリデーション追加（1 枚あたりで判定）
- フロントの `useMedia` で `extractApiErrorMessage()` によりサーバー本文を表示
- ダウンロードファイル名サニタイズ（制御文字・パス区切り → `_`）

## Test plan

- [x] develop CI 全 10 ジョブ pass
- [x] develop の build.yml 成功（GHCR にイメージ push 済み）
- [ ] main マージ後の release.yml が成功し、本番デプロイで実 ZIP 変換できること