### PR TITLE
fix(frontend): .mjs を application/javascript で配信

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -18,6 +18,14 @@ server {
         proxy_read_timeout 120s;
     }
 
+    # ECMAScript モジュール（.mjs）の MIME type 明示。
+    # nginx 同梱の mime.types に mjs が含まれないと application/octet-stream で
+    # 配信され、`X-Content-Type-Options: nosniff` と組み合わさってブラウザが
+    # JavaScript として解釈せず、動的 import（pdf.js worker など）が失敗する。
+    location ~ \.mjs$ {
+        types { } default_type application/javascript;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
## Summary

#232 でリリースしたPDF編集機能が本番で動作しない問題を修正。

PDFアップロード時に以下のエラーが出ていた:
\`\`\`
PDFの読み込みに失敗しました: Setting up fake worker failed: "Failed to fetch dynamically imported module: https://internal.kagiyama.net/assets/pdf.worker.min-iDqQPrd3.mjs".
\`\`\`

### 原因
nginx 同梱の mime.types に \`.mjs\` 拡張子が含まれず、worker ファイルが
\`Content-Type: application/octet-stream\` で配信されていた。
\`X-Content-Type-Options: nosniff\` ヘッダーと組み合わさり、ブラウザが
JavaScript として解釈拒否 → 動的 import 失敗。

### 修正
\`location ~ \.mjs$\` ブロックを追加し、\`application/javascript\` を明示。

## Test plan
- [x] ローカルで Docker build → \`Content-Type: application/javascript\` を確認
- [ ] 本番反映後、\`/pdf-edit\` でPDFをアップロードしてサムネが出ることを確認