### PR TITLE
Release: pdf.js worker MIME type 修正

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -18,6 +18,14 @@ server {
         proxy_read_timeout 120s;
     }
 
+    # ECMAScript モジュール（.mjs）の MIME type 明示。
+    # nginx 同梱の mime.types に mjs が含まれないと application/octet-stream で
+    # 配信され、`X-Content-Type-Options: nosniff` と組み合わさってブラウザが
+    # JavaScript として解釈せず、動的 import（pdf.js worker など）が失敗する。
+    location ~ \.mjs$ {
+        types { } default_type application/javascript;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
## Summary
#234 のフロントエンド緊急修正を本番反映するためのリリースPR。

PDF編集機能（先ほど #233 でリリース）が本番で動作しない問題（pdf.js worker の MIME type 不一致）の修正。

## Test plan
- [x] 修正PR #234 で pr-checks 全 pass
- [x] ローカルで Docker build → \`Content-Type: application/javascript\` を確認
- [x] develop で build.yml 全 pass（25121177740）
- [ ] release.yml 完了後、本番で \`/pdf-edit\` のPDFアップロードが成功することを確認